### PR TITLE
Require a pull request to be made before merge into main

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -36,4 +36,9 @@ resource "github_branch_protection" "main" {
     strict   = true
     contexts = var.required_ci_checks
   }
+
+  required_pull_request_reviews {
+    required_approving_review_count = 0
+  }
+
 }


### PR DESCRIPTION
Apparently there's no require_pull_request = true option, so I have to do this weird thing where I set the required approvals to zero just so we can enable pull request requirement.