### PR TITLE
Rename end-to-end-ci to allow for the composite action

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/tfe" {
   version     = "0.76.2"
   constraints = "~> 0.76.1"
   hashes = [
+    "h1:9g/u0KWe0JCruFecM3X2BnKdWEyDlxNiWD4z6oPA7n0=",
     "h1:yV1TipimZfKdq6NtrlE290CSfo1zJKk1SnCRsFsW9nI=",
     "zh:20f693826be72c3f5755af2ad68ead29bc67c9a5188f5f640b0eb0c7045c33b3",
     "zh:4253d3488aa3784427758455d878f22f8b1161fe1e372fbf1239e6785af325b7",

--- a/repositories.tf
+++ b/repositories.tf
@@ -8,7 +8,7 @@ locals {
       version_change_ci = "package-ci / version-change-ci / version-change-ci"
     }
 
-    end_to_end_ci = "end-to-end-ci"
+    end_to_end_ci = "end-to-end-ci / end-to-end-ci"
 
     terraform = {
       lint_ci = "terraform-lint-ci"
@@ -98,11 +98,15 @@ module "eslint_plugin_repository" {
 }
 
 module "components_repository" {
-  source             = "./modules/github/repository"
-  name               = "components"
-  description        = "A package containing common React components used across my projects."
-  visibility         = "public"
-  required_ci_checks = local.check_list.package
+  source      = "./modules/github/repository"
+  name        = "components"
+  description = "A package containing common React components used across my projects."
+  visibility  = "public"
+  required_ci_checks = concat([
+    for check in local.check_list.package :
+    check
+    if check != local.check_name.end_to_end_ci
+  ], ["end-to-end-ci"])
   has_pages          = true
   alex_up_bot_app_id = var.alex_up_bot_app_id
 }


### PR DESCRIPTION
Note that components must keep its old non-reusable workflow name because its end-to-end is slightly different.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
