### PR TITLE
Paralellise the linting and testing CI workflows in Lexicon

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -21,7 +21,8 @@ locals {
     }
 
     lexicon = {
-      ci = "lexicon-ci"
+      lint_ci = "lexicon-lint-ci"
+      test_ci = "lexicon-test-ci"
     }
 
     neurosongs = {
@@ -138,7 +139,7 @@ module "lexicon_repository" {
   name               = "lexicon"
   description        = "The true successor to Neurosongs, allowing users to write blogs and share them, with a dynamic editor."
   visibility         = "public"
-  required_ci_checks = concat(local.check_list.base, [local.check_name.lexicon.ci])
+  required_ci_checks = concat(local.check_list.base, [local.check_name.lexicon.lint_ci, local.check_name.lexicon.test_ci])
   alex_up_bot_app_id = var.alex_up_bot_app_id
 }
 


### PR DESCRIPTION
Usually the linting step takes longer than testing but doesn't need the whole environment setup, whereas testing itself is shorter but requires the environment setup. To make use of the fact that linting doesn't require as much setup, I have decided to parallelise linting and testing so that linting doesn't do the setup whereas testing does, therefore hopefully speeding up CI as a whole.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
