### PR TITLE
Update to PNPM v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-prefix=""

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "author": "alextheman",
   "license": "ISC",
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
   "devDependencies": {
     "@alextheman/eslint-plugin": "5.14.0",
     "@types/node": "25.6.0",
@@ -46,11 +46,5 @@
     "tsdown": "0.21.10",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.1"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "unrs-resolver"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  unrs-resolver: true
+  esbuild: true
+savePrefix: ""


### PR DESCRIPTION
This also includes migrating our usage of the pnpm field in package.json to use pnpm-workspace.yaml instead.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
