### PR TITLE
Rename lexicon project on Vercel to lexicon-front-end

### DIFF
--- a/vercel.tf
+++ b/vercel.tf
@@ -8,7 +8,7 @@ module "vercel_team" {
 module "lexicon_project" {
   source           = "./modules/vercel/project"
   vercel_team_id   = var.vercel_team_id
-  name             = "lexicon"
+  name             = "lexicon-front-end"
   framework        = "vite"
   output_directory = "apps/front-end/dist"
 }


### PR DESCRIPTION
This makes it clearer that it is managing purely the front-end. The back-end is planned to be deployed separately, either through Railway, or Neon and Render.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
