### PR TITLE
Require both that terraform-plan-ci and comment-terraform-plan must p…

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -11,8 +11,9 @@ locals {
     end_to_end_ci = "end-to-end-ci / end-to-end-ci"
 
     terraform = {
-      lint_ci = "terraform-lint-ci"
-      plan_ci = "comment-terraform-plan"
+      lint_ci      = "terraform-lint-ci"
+      plan_ci      = "terraform-plan-ci"
+      comment_plan = "comment-terraform-plan"
     }
 
     github_actions = {
@@ -71,6 +72,7 @@ module "infrastructure_repository" {
   required_ci_checks = concat(local.check_list.base, [
     local.check_name.terraform.lint_ci,
     local.check_name.terraform.plan_ci,
+    local.check_name.terraform.comment_plan
   ])
   alex_up_bot_app_id = var.alex_up_bot_app_id
   secrets = {


### PR DESCRIPTION
…ass CI

This feels a little more safe so that if the plan fails, then it also blocks the pull request. It may be true already but it relies on the fact that if plan fails, the comment-terraform-plan will also be considered a failure, which may not necessarily be true.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
