### PR TITLE
Set the history_retention_seconds to 21600

### DIFF
--- a/modules/neon/main.tf
+++ b/modules/neon/main.tf
@@ -8,8 +8,9 @@ terraform {
 }
 
 resource "neon_project" "default" {
-  name       = var.name
-  org_id     = var.org_id
-  pg_version = var.pg_version
+  name                      = var.name
+  org_id                    = var.org_id
+  pg_version                = var.pg_version
+  history_retention_seconds = 21600
 }
 


### PR DESCRIPTION
Apparently that is the maximum despite the provider trying to set a default of 86400 for some reason...

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
