### PR TITLE
Add a default database name to the Lexicon project

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -14,8 +14,9 @@ module "lexicon_project" {
 }
 
 module "lexicon_database" {
-  source     = "./modules/neon"
-  name       = "Lexicon"
-  org_id     = var.neon_organisation_id
-  pg_version = 17
+  source                = "./modules/neon"
+  name                  = "Lexicon"
+  org_id                = var.neon_organisation_id
+  pg_version            = 17
+  default_database_name = "lexicon-prod"
 }

--- a/modules/neon/main.tf
+++ b/modules/neon/main.tf
@@ -12,5 +12,10 @@ resource "neon_project" "default" {
   org_id                    = var.org_id
   pg_version                = var.pg_version
   history_retention_seconds = 21600
+
+  branch {
+    name          = var.default_branch_name
+    database_name = var.default_database_name
+  }
 }
 

--- a/modules/neon/variables.tf
+++ b/modules/neon/variables.tf
@@ -12,3 +12,15 @@ variable "org_id" {
   description = "Neon organisation ID."
   type        = string
 }
+
+variable "default_branch_name" {
+  description = "The name of the default branch."
+  type        = string
+  default     = "main"
+}
+
+variable "default_database_name" {
+  description = "The name of the default database."
+  type        = string
+}
+


### PR DESCRIPTION
It should be named after Lexicon itself.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
