### PR TITLE
Add Render web service for Lexicon

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -22,6 +22,7 @@ module "lexicon_database" {
 }
 
 module "lexicon_server" {
-  source = "./modules/render"
-  name   = "Lexicon"
+  source         = "./modules/render"
+  name           = "Lexicon"
+  repository_url = var.lexicon_repository_url
 }

--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -20,3 +20,18 @@ resource "render_project" "default" {
     }
   }
 }
+
+resource "render_web_service" "production" {
+  name           = "${var.name}-api"
+  plan           = "starter"
+  region         = "frankfurt"
+  environment_id = render_project.default.environments["production"].id
+
+  runtime_source = {
+    docker = {
+      auto_deploy = false
+      branch      = "main"
+      repo_url    = var.repository_url
+    }
+  }
+}

--- a/modules/render/variables.tf
+++ b/modules/render/variables.tf
@@ -1,4 +1,9 @@
 variable "name" {
-  description = "The name of the Render project"
+  description = "The name of the Render project."
+  type        = string
+}
+
+variable "repository_url" {
+  description = "The link to the repository to deploy from."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,8 @@ variable "render_owner_id" {
   description = "My Render user ID"
   type        = string
 }
+
+variable "lexicon_repository_url" {
+  description = "The link to the Lexicon GitHub repository"
+  type        = string
+}


### PR DESCRIPTION
I have decided in this case to go with trying a Docker-based deployment, as it seems to be the standard for most serious projects and gives us more control over the deployment cycle. The Dockerfile will have to be created in Lexicon in order for this to apply.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
