### PR TITLE
Add the Render Service ID to the Lexicon GitHub Actions variables

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -149,6 +149,9 @@ module "lexicon_repository" {
     VERCEL_PROJECT_ID = var.vercel_lexicon_project_id
     RENDER_DEPLOY_KEY = var.lexicon_render_key
   }
+  variables = {
+    RENDER_SERVICE_ID = var.lexicon_render_service_id
+  }
 }
 
 module "neurosongs_2_repository" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,8 @@ variable "lexicon_render_key" {
   type        = string
   sensitive   = true
 }
+
+variable "lexicon_render_service_id" {
+  description = "Render service ID for Lexicon back-end server"
+  type        = string
+}


### PR DESCRIPTION
I don't think it needs to be a secret variable as it is publicly accessible and people probably can't really do anything with it unless they have my actual secret Render API key anyway.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
