### PR TITLE
Add the Lexicon Database URL to Render

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -25,4 +25,7 @@ module "lexicon_server" {
   source         = "./modules/render"
   name           = "Lexicon"
   repository_url = var.lexicon_repository_url
+  secrets = {
+    DATABASE_URL = var.lexicon_database_url
+  }
 }

--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -35,3 +35,14 @@ resource "render_web_service" "production" {
     }
   }
 }
+
+resource "render_env_group" "default" {
+  name           = "${var.name} secrets"
+  environment_id = render_project.default.environments["production"].id
+  env_vars = {
+    for key, value in nonsensitive(var.secrets) :
+    key => {
+      value = value
+    }
+  }
+}

--- a/modules/render/variables.tf
+++ b/modules/render/variables.tf
@@ -7,3 +7,10 @@ variable "repository_url" {
   description = "The link to the repository to deploy from."
   type        = string
 }
+
+variable "secrets" {
+  description = "A map of secrets for the given Render project."
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}

--- a/repositories.tf
+++ b/repositories.tf
@@ -148,7 +148,7 @@ module "lexicon_repository" {
     VERCEL_ORG_ID     = var.vercel_team_id_lexicon_github
     VERCEL_PROJECT_ID = var.vercel_lexicon_project_id
     RENDER_DEPLOY_KEY = var.lexicon_render_key
-    DATABASE_URL      = var.lexicon_database_url
+    DATABASE_URL      = var.lexicon_database_url_encrypted
   }
   variables = {
     RENDER_SERVICE_ID = var.lexicon_render_service_id

--- a/variables.tf
+++ b/variables.tf
@@ -142,8 +142,14 @@ variable "lexicon_render_service_id" {
   type        = string
 }
 
-variable "lexicon_database_url" {
+variable "lexicon_database_url_encrypted" {
   description = "The Lexicon database URL, encrypted with respect to the Lexicon repository."
+  type        = string
+  sensitive   = true
+}
+
+variable "lexicon_database_url" {
+  description = "The Lexicon database URL in plaintext."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
Unfortunately it must be taken in as plaintext as Render does not provide something like encrypted_key the same way that GitHub does.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.

