### PR TITLE
Assign the secrets directly to the Render service

### DIFF
--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -34,22 +34,13 @@ resource "render_web_service" "production" {
       repo_url    = var.repository_url
     }
   }
-}
 
-resource "render_env_group" "default" {
-  name           = "${var.name} secrets"
-  environment_id = render_project.default.environments["production"].id
   env_vars = {
     for key, value in nonsensitive(var.secrets) :
     key => {
       value = value
     }
   }
-}
-
-resource "render_env_group_link" "default" {
-  env_group_id = render_env_group.default.id
-  service_ids  = [render_web_service.production.id]
 }
 
 resource "render_log_stream" "default" {


### PR DESCRIPTION
This may work better than having a separate env group and having to mess around with linking them.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
