### PR TITLE
Make the Vercel Organisation ID and project ID regular actions variables

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -145,12 +145,12 @@ module "lexicon_repository" {
   alex_up_bot_app_id = var.alex_up_bot_app_id
   secrets = {
     VERCEL_TOKEN      = var.vercel_api_token_lexicon_github
-    VERCEL_ORG_ID     = var.vercel_team_id_lexicon_github
-    VERCEL_PROJECT_ID = var.vercel_lexicon_project_id
     RENDER_DEPLOY_KEY = var.lexicon_render_key
     DATABASE_URL      = var.lexicon_database_url_encrypted
   }
   variables = {
+    VERCEL_ORG_ID     = var.vercel_team_id
+    VERCEL_PROJECT_ID = var.lexicon_vercel_project_id
     RENDER_SERVICE_ID = var.lexicon_render_service_id
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,16 +92,9 @@ variable "vercel_team_id" {
   type        = string
 }
 
-variable "vercel_team_id_lexicon_github" {
-  description = "The Vercel team ID for use in Lexicon, encrypted with respect to the Lexicon GitHub repository."
+variable "lexicon_vercel_project_id" {
+  description = "The ID for the Lexicon Vercel project."
   type        = string
-  sensitive   = true
-}
-
-variable "vercel_lexicon_project_id" {
-  description = "The ID for the Lexicon Vercel project, encrypted with respect to the Lexicon GitHub repository."
-  type        = string
-  sensitive   = true
 }
 
 variable "neon_api_key" {


### PR DESCRIPTION
They don't really need to be secrets as the IDs are publicly accessible in things like links etc. This makes them easier to debug and ensure they match what we expect them to be.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
