### PR TITLE
Add the existing Vercel URL as an allowed origin

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -29,8 +29,9 @@ module "lexicon_server" {
   name           = "Lexicon"
   repository_url = var.lexicon_repository_url
   secrets = {
-    DATABASE_URL = var.lexicon_database_url
-    NODE_ENV     = "production"
-    API_BASE_URL = var.lexicon_api_base_url
+    DATABASE_URL    = var.lexicon_database_url
+    NODE_ENV        = "production"
+    API_BASE_URL    = var.lexicon_api_base_url
+    ALLOWED_ORIGINS = "https://lexicon-front-n9bwg11a6-alextheman.vercel.app"
   }
 }


### PR DESCRIPTION
Eventually I would like to use a custom domain, but for now we'll use this.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
