### PR TITLE
Only run plan in CI if we are on a pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       checks: write
       contents: read
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,13 +100,11 @@ jobs:
           comment: "Discarded from GitHub Actions CI"
 
       - name: Save plan output
-        if: ${{ github.event_name == 'pull_request' }}
         env:
           COMMENT_BODY: ${{ steps.plan-output.outputs.comment-body }}
         run: echo "$COMMENT_BODY" > plan.txt
 
       - name: Upload the plan to be used in pull request comment
-        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-plan


### PR DESCRIPTION
This should hopefully speed up apply, as we will no longer have the plan-ci workflow running at the same time as apply, which sometimes causes the apply to be queued waiting for it to finish, even though there is a step to run the plan before apply anyway.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
