### PR TITLE
Change the build command so that it directly runs the front-end build

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -11,6 +11,7 @@ module "lexicon_project" {
   name             = "lexicon-front-end"
   framework        = "vite"
   output_directory = "apps/front-end/dist"
+  build_command    = "pnpm --dir apps/front-end run build"
   secrets = {
     VITE_API_BASE_URL = var.lexicon_api_base_url
   }


### PR DESCRIPTION
This may be a similar issue we had to the back-end, where running the build via Turborepo doesn't necessarily inject the environment variables in deployment for whatever reason.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
