### PR TITLE
Add the Lexicon API base URL in the workflow rather than in Vercel

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -12,9 +12,6 @@ module "lexicon_project" {
   framework        = "vite"
   output_directory = "apps/front-end/dist"
   build_command    = "pnpm --dir packages/models run build && pnpm --dir apps/front-end run build"
-  secrets = {
-    VITE_API_BASE_URL = var.lexicon_api_base_url
-  }
 }
 
 module "lexicon_database" {

--- a/repositories.tf
+++ b/repositories.tf
@@ -149,6 +149,7 @@ module "lexicon_repository" {
     DATABASE_URL      = var.lexicon_database_url_encrypted
   }
   variables = {
+    VITE_API_BASE_URL = var.lexicon_api_base_url
     VERCEL_ORG_ID     = var.vercel_team_id
     VERCEL_PROJECT_ID = var.lexicon_vercel_project_id
     RENDER_SERVICE_ID = var.lexicon_render_service_id


### PR DESCRIPTION
Otherwise the deployment will not have access to it, even if we set it in Vercel.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
