### PR TITLE
Use the regular build command instead of the manual ones

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -11,7 +11,6 @@ module "lexicon_project" {
   name             = "lexicon-front-end"
   framework        = "vite"
   output_directory = "apps/front-end/dist"
-  build_command    = "pnpm --dir packages/models run build && pnpm --dir apps/front-end run build"
 }
 
 module "lexicon_database" {


### PR DESCRIPTION
The issue with the environment variables was not the build command being the Turborepo one, but rather just the fact that we need to have them available in the deployment workflow itself.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
