### PR TITLE
Add our own custom domain for Lexicon

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -11,6 +11,7 @@ module "lexicon_project" {
   name             = "lexicon-front-end"
   framework        = "vite"
   output_directory = "apps/front-end/dist"
+  domain           = var.lexicon_domain
 }
 
 module "lexicon_database" {

--- a/modules/vercel/project/main.tf
+++ b/modules/vercel/project/main.tf
@@ -13,6 +13,9 @@ resource "vercel_project" "default" {
   framework        = var.framework
   output_directory = var.output_directory
   build_command    = var.build_command
+  vercel_authentication = {
+    deployment_type = "none"
+  }
 }
 
 resource "vercel_project_environment_variable" "secret" {

--- a/modules/vercel/project/main.tf
+++ b/modules/vercel/project/main.tf
@@ -32,3 +32,8 @@ resource "vercel_project_environment_variable" "default" {
   value      = each.value
   sensitive  = true
 }
+
+resource "vercel_project_domain" "default" {
+  project_id = vercel_project.default.id
+  domain     = var.domain
+}

--- a/modules/vercel/project/variables.tf
+++ b/modules/vercel/project/variables.tf
@@ -36,3 +36,8 @@ variable "variables" {
   description = "Non-sensitive variables to use in the given Vercel project."
   default     = {}
 }
+
+variable "domain" {
+  description = "The domain to use for the project."
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,8 @@ variable "lexicon_api_base_url" {
   description = "Base URL for Lexicon API"
   type        = string
 }
+
+variable "lexicon_domain" {
+  description = "The domain name for Lexicon"
+  type        = string
+}


### PR DESCRIPTION
I have just bought the domain on Cloudflare, so we need to register it with Vercel.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
