### PR TITLE
Add the new lexiconblogs.com domain as an allowed origin

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -30,6 +30,6 @@ module "lexicon_server" {
     DATABASE_URL    = var.lexicon_database_url
     NODE_ENV        = "production"
     API_BASE_URL    = var.lexicon_api_base_url
-    ALLOWED_ORIGINS = "https://lexicon-front-n9bwg11a6-alextheman.vercel.app"
+    ALLOWED_ORIGINS = "https://${var.lexicon_domain}"
   }
 }


### PR DESCRIPTION
We are now using our own custom domain rather than the automatically generated one. This should be more stable and less prone to changes, therefore making it more suitable for CORS.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
