### PR TITLE
Change the Render deployment strategy to use pre-built Docker images

### DIFF
--- a/lexicon.tf
+++ b/lexicon.tf
@@ -18,6 +18,7 @@ module "lexicon_server" {
   source         = "./modules/render"
   name           = "Lexicon"
   repository_url = var.lexicon_repository_url
+  docker_image   = "${var.docker_username}/lexicon"
   secrets = {
     DATABASE_URL         = var.lexicon_database_url
     NODE_ENV             = "production"

--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -28,10 +28,8 @@ resource "render_web_service" "production" {
   environment_id = render_project.default.environments["production"].id
 
   runtime_source = {
-    docker = {
-      auto_deploy = false
-      branch      = "main"
-      repo_url    = var.repository_url
+    image = {
+      image_url = var.docker_image
     }
   }
 

--- a/modules/render/variables.tf
+++ b/modules/render/variables.tf
@@ -14,3 +14,8 @@ variable "secrets" {
   sensitive   = true
   default     = {}
 }
+
+variable "docker_image" {
+  description = "The URL to the Docker image to deploy."
+  type        = string
+}


### PR DESCRIPTION
As of now we deploy by having Render run the Dockerfile. This changes that so that we control how the Dockerfile gets run, which also allows us to bring the Dockerfile logs into the GitHub Actions workflow output, reducing the need to context-switch to Render to monitor the logs.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
