### PR TITLE
Remove the Render log stream

### DIFF
--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -40,7 +40,3 @@ resource "render_web_service" "production" {
     }
   }
 }
-
-resource "render_log_stream" "default" {
-  preview = "send"
-}


### PR DESCRIPTION
We don't need it anymore now that we use an image-based deployment.