### PR TITLE
Use the organisation name instead of the organisation ID

### DIFF
--- a/modules/sentry/project/main.tf
+++ b/modules/sentry/project/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 resource "sentry_project" "default" {
-  organization = var.organisation_id
+  organization = var.organisation_name
   name         = var.name
   teams        = [var.organisation_name]
   platform     = var.platform

--- a/modules/sentry/project/variables.tf
+++ b/modules/sentry/project/variables.tf
@@ -4,11 +4,6 @@ variable "organisation_name" {
   default     = "alextheman231"
 }
 
-variable "organisation_id" {
-  description = "The ID of the Sentry organisation"
-  type        = string
-}
-
 variable "name" {
   description = "The name of the project."
   type        = string

--- a/stacks/lexicon.tf
+++ b/stacks/lexicon.tf
@@ -60,15 +60,13 @@ module "lexicon_project" {
 }
 
 module "lexicon_sentry_back_end" {
-  source          = "../modules/sentry/project"
-  organisation_id = var.sentry_organisation_id
-  name            = "lexicon-back-end"
-  platform        = "node-express"
+  source   = "../modules/sentry/project"
+  name     = "lexicon-back-end"
+  platform = "node-express"
 }
 
 module "lexicon_sentry_front_end" {
-  source          = "../modules/sentry/project"
-  organisation_id = var.sentry_organisation_id
-  name            = "lexicon-front-end"
-  platform        = "javascript-react"
+  source   = "../modules/sentry/project"
+  name     = "lexicon-front-end"
+  platform = "javascript-react"
 }


### PR DESCRIPTION
I just got an apply failure from using the ID, it seems.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
