### PR TITLE
Add the Sentry organisation token to the GitHub organisation secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,4 +50,5 @@ module "stacks" {
   sentry_organisation_id                     = var.sentry_organisation_id
   lexicon_back_end_sentry_dsn                = var.lexicon_back_end_sentry_dsn
   lexicon_front_end_sentry_dsn               = var.lexicon_front_end_sentry_dsn
+  sentry_organisation_token                  = var.sentry_organisation_token
 }

--- a/stacks/github_organisation.tf
+++ b/stacks/github_organisation.tf
@@ -11,6 +11,7 @@ module "github_organisation" {
     ALEX_UP_BOT_APP_ID = var.alex_up_bot_app_id
   }
   secrets = {
-    ALEX_UP_BOT_PRIVATE_KEY = var.alex_up_bot_private_key
+    ALEX_UP_BOT_PRIVATE_KEY   = var.alex_up_bot_private_key
+    SENTRY_ORGANISATION_TOKEN = var.sentry_organisation_token
   }
 }

--- a/stacks/variables.tf
+++ b/stacks/variables.tf
@@ -204,3 +204,9 @@ variable "lexicon_back_end_sentry_dsn" {
   description = "The Sentry DSN for the Lexicon back-end."
   type        = string
 }
+
+variable "sentry_organisation_token" {
+  description = "Sentry organisation token to use in GitHub Actions. This has been encrypted with respect to the alextheman231 GitHub organisation."
+  type        = string
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,8 @@ variable "lexicon_front_end_sentry_dsn" {
 variable "lexicon_back_end_sentry_dsn" {
   type = string
 }
+
+variable "sentry_organisation_token" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
It's not technically Lexicon-specific as it can be used in other projects, but as of now it is only being used by Lexicon.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
