### PR TITLE
Add end-to-end-ci as a required CI check in Lexicon

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -137,6 +137,7 @@ provider "registry.terraform.io/vercel/vercel" {
   constraints = ">= 4.8.0"
   hashes = [
     "h1:LDptyy10X6325qdvt+7dHdahQryK/lEMMNPSiTyz88s=",
+    "h1:dWkASEFLbSBSMyI1RqK8UpAq7kilI9dCquRV35YaYtE=",
     "zh:00e198bdee517d4f9c9848971c62312c087757efc726795debe24569bc842d38",
     "zh:08102e24a768418c928c9f78cf97161d4184959039a2b52e17e5795bfc22d123",
     "zh:136cfd3bec6647b41fdcc9baa4662eb8ca8a43fc03d9fdd949fe55bd6b656ec1",

--- a/stacks/ci_jobs.tf
+++ b/stacks/ci_jobs.tf
@@ -22,8 +22,9 @@ locals {
     }
 
     lexicon = {
-      lint_ci = "lexicon-lint-ci"
-      test_ci = "lexicon-test-ci"
+      lint_ci       = "lexicon-lint-ci"
+      test_ci       = "lexicon-test-ci"
+      end_to_end_ci = "end-to-end-ci"
     }
 
     neurosongs = {

--- a/stacks/lexicon.tf
+++ b/stacks/lexicon.tf
@@ -1,9 +1,13 @@
 module "lexicon_repository" {
-  source             = "../modules/github/repository"
-  name               = "lexicon"
-  description        = "The true successor to Neurosongs, allowing users to write blogs and share them, with a dynamic editor."
-  visibility         = "public"
-  required_ci_checks = concat(local.check_list.base, [local.check_name.lexicon.lint_ci, local.check_name.lexicon.test_ci])
+  source      = "../modules/github/repository"
+  name        = "lexicon"
+  description = "The true successor to Neurosongs, allowing users to write blogs and share them, with a dynamic editor."
+  visibility  = "public"
+  required_ci_checks = concat(local.check_list.base, [
+    local.check_name.lexicon.lint_ci,
+    local.check_name.lexicon.test_ci,
+    local.check_name.lexicon.end_to_end_ci
+  ])
   alex_up_bot_app_id = var.alex_up_bot_app_id
   secrets = {
     VERCEL_TOKEN      = var.vercel_api_token_lexicon_github


### PR DESCRIPTION
# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
