### PR TITLE
Remove the old v17 Neon database

### DIFF
--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -25,14 +25,6 @@ module "lexicon_repository" {
   }
 }
 
-module "lexicon_database" {
-  source                = "../modules/neon"
-  name                  = "Lexicon"
-  org_id                = var.neon_organisation_id
-  pg_version            = 17
-  default_database_name = "lexicon-prod"
-}
-
 module "lexicon_database_v18" {
   source                = "../modules/neon"
   name                  = "Lexicon"


### PR DESCRIPTION
We've migrated to Postgres v18 and I can confirm the migration has worked. The Neon project does include all the data that was previously stored. The existing Neon project secrets have also been changed to point to the new v18 database.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
