### PR TITLE
Make the Lexicon v18 database the canonical database

### DIFF
--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = module.services.module.lexicon_database_v18
+  to   = module.services.module.lexicon_database
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -25,7 +25,7 @@ module "lexicon_repository" {
   }
 }
 
-module "lexicon_database_v18" {
+module "lexicon_database" {
   source                = "../modules/neon"
   name                  = "Lexicon"
   org_id                = var.neon_organisation_id


### PR DESCRIPTION
Now we've officially removed the v17 project, the v18 project can take its place and name.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
