### PR TITLE
Give a 30-second review window of the plan before letting CI pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
 
             ${{ steps.get-plan.outputs.comment-body }}
 
+      - name: Give a 30-second plan review window before passing
+        run: sleep 30
+
   actions-ci:
     permissions:
       contents: read


### PR DESCRIPTION
This ensures that people actually have time to review the plan even if auto-merge is enabled. Previously there was a chance that the pull request can be merged immediately after the comment appears, with no time to actually review it, whereas now there is at least a 30-second buffer.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
