### PR TITLE
Add the existing Lexicon DNS record in Cloudflare to the configuration

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,23 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/docker/docker" {
   version     = "0.6.0"
   constraints = ">= 0.2.0"

--- a/main.tf
+++ b/main.tf
@@ -51,4 +51,6 @@ module "services" {
   lexicon_back_end_sentry_dsn                = var.lexicon_back_end_sentry_dsn
   lexicon_front_end_sentry_dsn               = var.lexicon_front_end_sentry_dsn
   sentry_organisation_token                  = var.sentry_organisation_token
+  cloudflare_api_token                       = var.cloudflare_api_token
+  cloudflare_lexicon_zone_id                 = var.cloudflare_lexicon_zone_id
 }

--- a/modules/cloudflare/dns/main.tf
+++ b/modules/cloudflare/dns/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">=5.0.0"
+    }
+  }
+}
+
+resource "cloudflare_dns_record" "default" {
+  name    = var.name
+  ttl     = var.ttl
+  type    = var.type
+  zone_id = var.zone_id
+  content = var.content
+}

--- a/modules/cloudflare/dns/variables.tf
+++ b/modules/cloudflare/dns/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "DNS record name (or @ for the zone apex) in Punycode."
+  type        = string
+}
+
+variable "ttl" {
+  description = "Time to line of the DNS record in seconds."
+  default     = 600
+  type        = number
+}
+
+variable "type" {
+  description = "Record type. Available values: \"A\", \"AAAA\", \"CNAME\", \"MX\", \"NS\", \"OPENPGPKEY\", \"PTR\", \"TXT\", \"CAA\", \"CERT\", \"DNSKEY\", \"DS\", \"HTTPS\", \"LOC\", \"NAPTR\", \"SMIMEA\", \"SRV\", \"SSHFP\", \"SVCB\", \"TLSA\", \"URI\"."
+  type        = string
+}
+
+variable "zone_id" {
+  description = "The Cloudflare Zone ID"
+  type        = string
+}
+
+variable "content" {
+  description = "A valid IPv4 address"
+  type        = string
+  default     = null
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -76,3 +76,11 @@ module "lexicon_sentry_front_end" {
   name     = "lexicon-front-end"
   platform = "javascript-react"
 }
+
+module "lexicon_dns_record" {
+  source  = "../modules/cloudflare/dns"
+  name    = "lexiconblogs.com"
+  type    = "CNAME"
+  zone_id = var.cloudflare_lexicon_zone_id
+  content = "e7098f9ead20285a.vercel-dns-017.com"
+}

--- a/services/main.tf
+++ b/services/main.tf
@@ -28,6 +28,10 @@ terraform {
       source  = "jianyuan/sentry"
       version = ">=0.14.3"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">=5.0.0"
+    }
   }
 }
 
@@ -65,4 +69,8 @@ provider "docker" {
 
 provider "sentry" {
   token = var.sentry_infrastructure_token
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -210,3 +210,14 @@ variable "sentry_organisation_token" {
   type        = string
   sensitive   = true
 }
+
+variable "cloudflare_api_token" {
+  description = "Token to interact with Cloudflare"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_lexicon_zone_id" {
+  description = "The Cloudflare Lexicon Zone ID"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -205,3 +205,13 @@ variable "sentry_organisation_token" {
   type      = string
   sensitive = true
 }
+
+variable "cloudflare_api_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "cloudflare_lexicon_zone_id" {
+  description = "The Cloudflare Lexicon Zone ID"
+  type        = string
+}


### PR DESCRIPTION
# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
