### PR TITLE
Add a custom API domain to the Lexicon render deployment

### DIFF
--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -39,4 +39,6 @@ resource "render_web_service" "production" {
       value = value
     }
   }
+
+  custom_domains = [for value in var.custom_domains : { name : value }]
 }

--- a/modules/render/variables.tf
+++ b/modules/render/variables.tf
@@ -19,3 +19,8 @@ variable "docker_image" {
   description = "The URL to the Docker image to deploy."
   type        = string
 }
+
+variable "custom_domains" {
+  description = "Custom domains to associate with the service"
+  type        = list(string)
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -47,6 +47,7 @@ module "lexicon_server" {
     GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
     SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
   }
+  custom_domains = ["api.lexiconblogs.com"]
 }
 
 module "lexicon_image" {


### PR DESCRIPTION
I may then need to configure the DNS records manually in Render and add the subdomain to Cloudflare as a second step.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
