### PR TITLE
Add the Lexicon API Cloudflare DNS record

### DIFF
--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -85,3 +85,11 @@ module "lexicon_dns_record" {
   zone_id = var.cloudflare_lexicon_zone_id
   content = "e7098f9ead20285a.vercel-dns-017.com"
 }
+
+module "lexicon_api_dns_record" {
+  source  = "../modules/cloudflare/dns"
+  name    = "api.lexiconblogs.com"
+  type    = "CNAME"
+  zone_id = var.cloudflare_lexicon_zone_id
+  content = "lexicon-api-lryv.onrender.com"
+}


### PR DESCRIPTION
Needed for Render to be able to use our new subdomain.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
