### PR TITLE
Rename lexicon_api_base_url to lexicon_api_domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "services" {
   tfe_token                                  = var.tfe_token
   tfe_org_token                              = var.tfe_org_token
   billing_email                              = var.billing_email
-  lexicon_api_base_url                       = var.lexicon_api_base_url
+  lexicon_api_domain                         = var.lexicon_api_domain
   lexicon_database_url                       = var.lexicon_database_url
   lexicon_google_client_id                   = var.lexicon_google_client_id
   neon_organisation_id                       = var.neon_organisation_id

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -16,7 +16,7 @@ module "lexicon_repository" {
     DOCKER_PAT        = var.docker_pat_lexicon_encrypted
   }
   variables = {
-    VITE_API_BASE_URL    = "https://${var.lexicon_api_base_url}"
+    VITE_API_BASE_URL    = "https://${var.lexicon_api_domain}"
     VERCEL_ORG_ID        = var.vercel_team_id
     VERCEL_PROJECT_ID    = var.lexicon_vercel_project_id
     RENDER_SERVICE_ID    = var.lexicon_render_service_id
@@ -41,13 +41,13 @@ module "lexicon_server" {
   secrets = {
     DATABASE_URL         = var.lexicon_database_url
     NODE_ENV             = "production"
-    API_BASE_URL         = "https://${var.lexicon_api_base_url}"
+    API_BASE_URL         = "https://${var.lexicon_api_domain}"
     ALLOWED_ORIGINS      = "https://${var.lexicon_domain}"
     GOOGLE_CLIENT_ID     = var.lexicon_google_client_id
     GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
     SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
   }
-  custom_domains = [var.lexicon_api_base_url]
+  custom_domains = [var.lexicon_api_domain]
 }
 
 module "lexicon_image" {
@@ -88,7 +88,7 @@ module "lexicon_dns_record" {
 
 module "lexicon_api_dns_record" {
   source  = "../modules/cloudflare/dns"
-  name    = var.lexicon_api_base_url
+  name    = var.lexicon_api_domain
   type    = "CNAME"
   zone_id = var.cloudflare_lexicon_zone_id
   content = "lexicon-api-lryv.onrender.com"

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -146,8 +146,8 @@ variable "lexicon_database_url" {
   sensitive   = true
 }
 
-variable "lexicon_api_base_url" {
-  description = "Base URL for Lexicon API"
+variable "lexicon_api_domain" {
+  description = "Domain for Lexicon API"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -146,8 +146,8 @@ variable "lexicon_database_url" {
   sensitive   = true
 }
 
-variable "lexicon_api_base_url" {
-  description = "Base URL for Lexicon API"
+variable "lexicon_api_domain" {
+  description = "Domain name for Lexicon API"
   type        = string
 }
 


### PR DESCRIPTION
This is clearer as it does not contain the protocol at the start. This is by design as it makes it more reusable.

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
