### PR TITLE
Add the Google OAuth configuration to the Terraform configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .alex-c-line.private.config.js
 dist-configs
 .DS_Store
+google-key.json

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -34,6 +34,26 @@ provider "registry.terraform.io/docker/docker" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.35.0"
+  constraints = ">= 7.35.0"
+  hashes = [
+    "h1:7n727Y4eGRZZeaLOl7ghl0AB19lqboIHPp8YybXZ7eA=",
+    "zh:02c62a2fdf8f9b268054a7a7c3478760e5149889e0c47572940a5503291bb8a5",
+    "zh:1ca325734f7c4a0f39c86caef38d618db64ca2d9b052f763f469af4e41fb8ea6",
+    "zh:5777b1dd32e3705735743c3749ccf826ebd2ca3ab774f912379fee2ad235e242",
+    "zh:61ea1eb889bd037ccf39d5108d686aff67474c1696496567eaf10c4f583e5a3d",
+    "zh:77308f5d2e1923dab36e320aa9774e8c09e1e4d0185d68f36eedeacd176c7a43",
+    "zh:841c40ba2141654aa17ab22c3690fea6fd7c2be0cdb96e519ea6360cab20a54f",
+    "zh:8bea49dabe822f3a852d22e30cd2faf233437b56fa102f9087cfd40b026c2fca",
+    "zh:8d94331d0dd2b200594aade652f78647377d79d863bcb0e17e3bf4b0a8fe3b73",
+    "zh:a1c8a93728b0bf7072e69846380bebee985ebc40e0f6a9277f6ba0c3b9541137",
+    "zh:bee175415263afe9953a5af2180db5cbba653505707d6f88e6d8dd0b04c990b5",
+    "zh:cd63ba21833277871da2390865fcec8317bc3513cf91bd2d5ef6144192207b76",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tfe" {
   version     = "0.77.0"
   constraints = ">= 0.76.1"

--- a/main.tf
+++ b/main.tf
@@ -53,4 +53,6 @@ module "services" {
   sentry_organisation_token                  = var.sentry_organisation_token
   cloudflare_api_token                       = var.cloudflare_api_token
   cloudflare_lexicon_zone_id                 = var.cloudflare_lexicon_zone_id
+  lexicon_google_key                         = var.lexicon_google_key
+  lexicon_google_project_id                  = var.lexicon_google_project_id
 }

--- a/modules/google/main.tf
+++ b/modules/google/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=7.35.0"
+    }
+  }
+}
+
+provider "google" {
+  credentials = var.credentials
+  project     = var.project_id
+}
+
+resource "google_iam_oauth_client" "default" {
+  allowed_scopes        = ["openid"]
+  allowed_grant_types   = ["authorization_code"]
+  allowed_redirect_uris = var.allowed_redirect_uris
+  oauth_client_id       = var.google_client_id
+  location              = var.location
+  display_name          = var.display_name
+  description           = var.description
+}

--- a/modules/google/variables.tf
+++ b/modules/google/variables.tf
@@ -1,0 +1,37 @@
+variable "credentials" {
+  description = "The path to, or contents of, a service account key file in JSON format"
+  type        = string
+  sensitive   = true
+}
+
+variable "google_client_id" {
+  description = "The ID to use for the OauthClient"
+  type        = string
+}
+
+variable "allowed_redirect_uris" {
+  description = "The list of redirect uris that is allowed to redirect back when authorization process is completed."
+  type        = list(string)
+}
+
+variable "location" {
+  description = "Resource ID segment making up resource name. It identifies the resource within its parent collection as described in https://google.aip.dev/122."
+  type        = string
+}
+
+variable "project_id" {
+  description = "The Google project ID"
+  type        = string
+}
+
+variable "display_name" {
+  description = "A user-specified display name of the OAuth Client."
+  type        = string
+  default     = null
+}
+
+variable "description" {
+  description = "A user-specified description of the OAuth Client."
+  type        = string
+  default     = ""
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -93,3 +93,14 @@ module "lexicon_api_dns_record" {
   zone_id = var.cloudflare_lexicon_zone_id
   content = "lexicon-api-lryv.onrender.com"
 }
+
+module "lexicon_google_project" {
+  source                = "../modules/google"
+  credentials           = var.lexicon_google_key
+  google_client_id      = var.lexicon_google_client_id
+  allowed_redirect_uris = ["https://${var.lexicon_api_domain}/api/v1/auth/google/callback"]
+  location              = "global"
+  project_id            = var.lexicon_google_project_id
+  display_name          = "Lexicon OAuth Client 2"
+  description           = "The Google OAuth Client for Lexicon to allow for Google SSO."
+}

--- a/services/main.tf
+++ b/services/main.tf
@@ -32,6 +32,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = ">=5.0.0"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = ">=7.35.0"
+    }
   }
 }
 

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -221,3 +221,14 @@ variable "cloudflare_lexicon_zone_id" {
   description = "The Cloudflare Lexicon Zone ID"
   type        = string
 }
+
+variable "lexicon_google_key" {
+  description = "Key for the Lexicon Google project"
+  type        = string
+  sensitive   = true
+}
+
+variable "lexicon_google_project_id" {
+  description = "The Google Project ID for Lexicon"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,14 @@ variable "cloudflare_lexicon_zone_id" {
   description = "The Cloudflare Lexicon Zone ID"
   type        = string
 }
+
+variable "lexicon_google_key" {
+  description = "Key for the Lexicon Google project"
+  type        = string
+  sensitive   = true
+}
+
+variable "lexicon_google_project_id" {
+  description = "The Google Project ID for Lexicon"
+  type        = string
+}


### PR DESCRIPTION
I seem to be having problems importing this, so I think, given that this is easy to recreate I would like to create this Terraform-controlled one, then change everything else to point to that, then remove the old OAuth. If the apply succeeds we'll go with that, otherwise we'll have to clean up the state.

Please let this work...

# Manual Change

This is a change to `infrastructure` that requires manual changes to the managed Terraform resources. AlexMan123456 **MUST** confirm by approval (or authorship of pull request) that these changes have been made before this can be merged in.

Please see the commits tab of this pull request for the description of changes.
