### PR TITLE
Add a health check path to the Lexicon Render deployment

### DIFF
--- a/modules/render/main.tf
+++ b/modules/render/main.tf
@@ -22,10 +22,11 @@ resource "render_project" "default" {
 }
 
 resource "render_web_service" "production" {
-  name           = "${var.name}-api"
-  plan           = "starter"
-  region         = "frankfurt"
-  environment_id = render_project.default.environments["production"].id
+  name              = "${var.name}-api"
+  plan              = "starter"
+  region            = "frankfurt"
+  environment_id    = render_project.default.environments["production"].id
+  health_check_path = var.health_check_path
 
   runtime_source = {
     image = {

--- a/modules/render/variables.tf
+++ b/modules/render/variables.tf
@@ -24,3 +24,9 @@ variable "custom_domains" {
   description = "Custom domains to associate with the service"
   type        = list(string)
 }
+
+variable "health_check_path" {
+  description = "The path where the server will always return a 200 response. Used to monitor the app and for zero downtime deploys."
+  type        = string
+  default     = "/api"
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -38,6 +38,7 @@ module "lexicon_server" {
   name           = "Lexicon"
   repository_url = var.lexicon_repository_url
   docker_image   = "${var.docker_username}/lexicon"
+
   secrets = {
     DATABASE_URL         = var.lexicon_database_url
     NODE_ENV             = "production"
@@ -47,7 +48,9 @@ module "lexicon_server" {
     GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
     SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
   }
-  custom_domains = [var.lexicon_api_domain]
+
+  custom_domains    = [var.lexicon_api_domain]
+  health_check_path = "/api/v1"
 }
 
 module "lexicon_image" {


### PR DESCRIPTION
Won't fix the current auth issue but will at least get rid of a console error in the deployment where it can't find the / endpoint.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
