### PR TITLE
Revert "Revert adding the repository labels"

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -83,6 +83,7 @@ provider "registry.terraform.io/jianyuan/sentry" {
   version     = "0.15.1"
   constraints = ">= 0.14.3"
   hashes = [
+    "h1:7vJt+kCOfk0rByvAl110Pt2zlmrQqcq0YM3wsBtzo0E=",
     "h1:kD6o4mNLVcPtAWQDdJriJe+SVur560j8SC5uQsCRNig=",
     "zh:0c324fea44f56b6813bd8cb0be3e0548deffb3e587c0a2f92ac425028444c11c",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",

--- a/modules/github/repository/main.tf
+++ b/modules/github/repository/main.tf
@@ -183,3 +183,39 @@ resource "github_actions_variable" "default" {
   variable_name = each.key
   value         = each.value
 }
+
+resource "github_issue_label" "low_risk" {
+  count = !var.archived ? 1 : 0
+
+  repository  = github_repository.default.name
+  name        = "low risk"
+  color       = "008672"
+  description = "Low risk change"
+}
+
+resource "github_issue_label" "medium_risk" {
+  count = !var.archived ? 1 : 0
+
+  repository  = github_repository.default.name
+  name        = "medium risk"
+  color       = "7057FF"
+  description = "Medium risk change"
+}
+
+resource "github_issue_label" "high_risk" {
+  count = !var.archived ? 1 : 0
+
+  repository  = github_repository.default.name
+  name        = "high risk"
+  color       = "E4E669"
+  description = "High risk change"
+}
+
+resource "github_issue_label" "default" {
+  for_each = var.labels
+
+  repository  = github_repository.default.name
+  name        = each.key
+  color       = each.value.color
+  description = each.value.description
+}

--- a/modules/github/repository/variables.tf
+++ b/modules/github/repository/variables.tf
@@ -64,3 +64,12 @@ variable "variables" {
   description = "Non-sensitive variables to use in GitHub Actions workflows."
   default     = {}
 }
+
+variable "labels" {
+  type = map(object({
+    color       = string
+    description = string
+  }))
+
+  default = {}
+}

--- a/services/common_labels.tf
+++ b/services/common_labels.tf
@@ -1,0 +1,76 @@
+locals {
+  labels = {
+    standard = {
+      "breaking change" = {
+        color       = "B60205"
+        description = "Introduces breaking changes."
+      }
+      "new feature" = {
+        color       = "A2EEEF"
+        description = "Introduces new functionality."
+      }
+      "bug fix" = {
+        color       = "D73A4A"
+        description = "Fixes a bug."
+      }
+      "tooling" = {
+        color       = "5319E7"
+        description = "Tooling and dependency changes."
+      }
+      "documentation" = {
+        color       = "0075CA"
+        description = "Documentation updates."
+      }
+      "internal" = {
+        color       = "FBCA04"
+        description = "Changes to internal APIs or implementation details."
+      }
+      "refactor" = {
+        color       = "C2E0C6"
+        description = "Code quality improvements without behavioural changes."
+      }
+      "miscellaneous" = {
+        color       = "BFDADC"
+        description = "Changes that do not fit another category."
+      }
+    }
+    infrastructure = {
+      "manual change" = {
+        color       = "FBCA04"
+        description = "Requires manual Terraform actions and confirmation from AlexMan123456 before deployment."
+      }
+      "irreversible destruction" = {
+        color       = "B60205"
+        description = "Destroys managed resources."
+      }
+      "resource update" = {
+        color       = "5319E7"
+        description = "Updates an existing resource."
+      }
+    }
+    app = {
+      "migration" = {
+        color       = "E99695"
+        description = "Involves a database migration."
+      }
+      "authentication" = {
+        color       = "0052CC"
+        description = "Changes to the sign-in/sign-up process."
+      }
+      "authorisation" = {
+        color       = "1D76DB"
+        description = "Changes to user access permissions."
+      }
+      "ui" = {
+        color       = "7057FF"
+        description = "Changes the layout of the UI."
+      }
+
+      "accessibility" = {
+        color       = "0E8A16"
+        description = "Improves the accessibility without changing the UI layout."
+      }
+    }
+  }
+}
+

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -24,4 +24,5 @@ module "infrastructure_repository" {
     TFE_TOKEN  = var.tfe_token
     PASSPHRASE = var.tf_via_pr_passphrase
   }
+  labels = merge(local.labels.standard, local.labels.infrastructure)
 }

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -23,6 +23,7 @@ module "lexicon_repository" {
     DOCKER_USERNAME      = var.docker_username
     FRONT_END_SENTRY_DSN = var.lexicon_front_end_sentry_dsn
   }
+  labels = merge(local.labels.standard, local.labels.app)
 }
 
 module "lexicon_database" {

--- a/services/media.tf
+++ b/services/media.tf
@@ -5,4 +5,5 @@ module "media_repository" {
   visibility         = "public"
   required_ci_checks = concat(local.check_list.base, [local.check_name.media.ci])
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }

--- a/services/packages.tf
+++ b/services/packages.tf
@@ -6,6 +6,7 @@ module "utility_repository" {
   required_ci_checks = local.check_list.package
   alex_up_bot_app_id = var.alex_up_bot_app_id
   has_pages          = true
+  labels             = local.labels.standard
 }
 
 module "eslint_plugin_repository" {
@@ -15,6 +16,7 @@ module "eslint_plugin_repository" {
   visibility         = "public"
   required_ci_checks = local.check_list.package
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }
 
 module "components_repository" {
@@ -29,6 +31,7 @@ module "components_repository" {
   ], [local.check_name.components.end_to_end_ci])
   has_pages          = true
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }
 
 module "alex_c_line_repository" {
@@ -38,6 +41,7 @@ module "alex_c_line_repository" {
   visibility         = "public"
   required_ci_checks = local.check_list.package
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }
 
 module "github_actions_repository" {
@@ -51,6 +55,7 @@ module "github_actions_repository" {
   )
   has_pages          = true
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }
 
 module "typescript_actions_repository" {
@@ -60,4 +65,5 @@ module "typescript_actions_repository" {
   visibility         = "public"
   required_ci_checks = concat(local.check_list.base, [local.check_name.package.source_code_ci])
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  labels             = local.labels.standard
 }


### PR DESCRIPTION
This reverts commit d3823709fd410c40c11fad5f625f935a31d00477.

The default labels have been removed so I am now comfortable adding back our own ones.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
