### PR TITLE
Add resource creation and resource replacement tags to infrastructure…

### DIFF
--- a/services/common_labels.tf
+++ b/services/common_labels.tf
@@ -55,6 +55,14 @@ locals {
         color       = "5319E7"
         description = "Updates an existing resource."
       }
+      "resource creation" = {
+        color       = "28A745"
+        description = "Creates a new managed resource."
+      }
+      "resource replacement" = {
+        color       = "E99695"
+        description = "Replaces an existing managed resource."
+      }
     }
     app = {
       "migration" = {


### PR DESCRIPTION
… repository.

This allows us to draw more attention to plans that fully replace a resource, as they tend to be more risky.