### PR TITLE
Update Terraform to v1.15

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.14.3
+          terraform_version: 1.15
 
       - name: Initialise Terraform
         run: terraform init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.14.3
+          terraform_version: 1.15
 
       - name: Install dependencies
         run: pnpm install
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.14.3
+          terraform_version: 1.15
 
       - name: Run the plan
         uses: op5dev/tf-via-pr@39ed2635c056ca408ed24cc5c2baf0ef4381a7a5 # v13.7.4

--- a/modules/tfe/workspace/main.tf
+++ b/modules/tfe/workspace/main.tf
@@ -13,6 +13,7 @@ resource "tfe_workspace" "default" {
   description           = var.description
   file_triggers_enabled = false
   speculative_enabled   = true
+  terraform_version     = var.terraform_version
 }
 
 resource "tfe_workspace_settings" "default" {

--- a/modules/tfe/workspace/variables.tf
+++ b/modules/tfe/workspace/variables.tf
@@ -13,3 +13,9 @@ variable "organisation_name" {
   description = "The TFE organisation name."
   type        = string
 }
+
+variable "terraform_version" {
+  description = "The Terraform version"
+  type        = string
+  default     = "latest"
+}

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -7,6 +7,7 @@ module "infrastructure_workspace" {
   source            = "../modules/tfe/workspace"
   name              = "infrastructure"
   organisation_name = var.tfe_organisation_name
+  terraform_version = "~>1.15"
 }
 
 module "infrastructure_repository" {


### PR DESCRIPTION
We were previously just using v1.14.3, but it seems that v1.15 is the latest. As such, I would like to update to that.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
