### PR TITLE
Refactor apply so that we own all the logic

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -13,8 +13,7 @@ env:
 
 jobs:
   terraform-apply:
-    if: github.repository == 'alextheman231/infrastructure'
-    name: "Terraform Apply"
+    if: ${{ github.repository == 'alextheman231/infrastructure' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,24 +23,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Upload Configuration
-        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
-        id: apply-upload
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          workspace: ${{ env.TF_WORKSPACE }}
-          directory: ./
+          terraform_version: 1.14.3
+
+      - name: Initialise Terraform
+        run: terraform init -backend=false
 
       - name: Verify the plan
-        uses: hashicorp/tfc-workflows-github/actions/create-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
-        id: plan-run
-        with:
-          workspace: ${{ env.TF_WORKSPACE }}
-          configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
+        run: terraform plan -out=tfplan
 
       - name: Approve and apply the configuration
-        uses: hashicorp/tfc-workflows-github/actions/apply-run@8e08d1ba957673f5fbf971a22b3219639dc45661 # v1.3.2
-        if: fromJSON(steps.plan-run.outputs.payload).data.attributes.actions.IsConfirmable
-        id: apply
-        with:
-          run: ${{ steps.plan-run.outputs.run_id }}
-          comment: "Apply Run from GitHub Actions CI ${{ github.sha }}"
+        run: terraform apply tfplan

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .alex-c-line.private.config.js
 dist-configs
 .DS_Store
+tfplan


### PR DESCRIPTION
Previously we were using the Hashicorp composite actions, which worked, but this should allow us to actually see the plan/apply in the action logs rather than just 'Planning' or 'Applying' constantly.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
