### PR TITLE
Disable the Terraform wrapper

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -27,6 +27,7 @@ jobs:
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: 1.15
+          terraform_wrapper: false
 
       - name: Initialise Terraform
         run: terraform init


### PR DESCRIPTION
So that detailed-exitcode works

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
