### PR TITLE
Add a deployment label to apps

### DIFF
--- a/services/common_labels.tf
+++ b/services/common_labels.tf
@@ -83,6 +83,10 @@ locals {
         color       = "0E8A16"
         description = "Improves the accessibility without changing the UI layout."
       }
+      "deployment" = {
+        color       = "0366D6"
+        description = "Changes deployment, hosting, build, or release behaviour."
+      }
     }
   }
 }


### PR DESCRIPTION
This is useful for pull requests in apps that change deployment behaviour, as they're often their own category with their fair share of risk.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
