### PR TITLE
Set up an initial AWS configuration

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -35,6 +35,30 @@ provider "registry.terraform.io/docker/docker" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.51.0"
+  constraints = ">= 6.51.0"
+  hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
+    "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
+    "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
+    "zh:190a46da0c69082b74da48238ce134d2fc9893e09122ac249c5689f88eab7e13",
+    "zh:1b312a4b53fa3cf731f95e674c033865feea5455f163b86136f2614424637293",
+    "zh:2b319814806222c5aba196b1a78756a6b36dc5c91f85edda349234d8a2f20a6a",
+    "zh:2bddf92c8efc6ad445a2eb8a0e5f88742a0596392c3a4ebc350ebb4105a4a96d",
+    "zh:3bef0c4f675c09034ff017cf899977b1765b2c0b3d1e489bcb06a5fcac316e2d",
+    "zh:47c46b5aa22199638fed5c93b195bbfd1182a1408edad4e5c39d4a73a04493f6",
+    "zh:5f808699650f6db961964466c77f5a581eab142a91c2e54810bb09b6f2fcd3f2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ada97e6be10164f452e278c23412b8597698a9c95ffb68fe83629d63d85906f3",
+    "zh:c4d73a91810d8dbcf9abbd431d41fcceebb48f8b6fd3c28a84bb3c6ed08be2e9",
+    "zh:c63ec875d38fc557b16b0b2b0ab1c7635852799453113240e21a52409de94a71",
+    "zh:cdd0209a755fc3aa14855aa013dae4b166a2fc7f6d3cbb673f7ff2142f5b63a2",
+    "zh:e5e665a27290391fd1bffc093ab68b596f6c507785be2e3f0949fab4fd6aec1b",
+    "zh:f6c42046a31d65eff2793737656b38931f90318b53661046bb84326cd4cb558f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tfe" {
   version     = "0.78.0"
   constraints = ">= 0.76.1"

--- a/main.tf
+++ b/main.tf
@@ -53,4 +53,6 @@ module "services" {
   sentry_organisation_token                  = var.sentry_organisation_token
   cloudflare_api_token                       = var.cloudflare_api_token
   cloudflare_lexicon_zone_id                 = var.cloudflare_lexicon_zone_id
+  aws_access_key                             = var.aws_access_key
+  aws_secret_key                             = var.aws_secret_key
 }

--- a/modules/aws/main.tf
+++ b/modules/aws/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+data "aws_ssoadmin_instances" "default" {}
+
+locals {
+  identity_center_instance_arn = tolist(
+    data.aws_ssoadmin_instances.default.arns
+  )[0]
+
+  identity_store_id = tolist(
+    data.aws_ssoadmin_instances.default.identity_store_ids
+  )[0]
+}
+
+resource "aws_ssoadmin_permission_set" "administrator" {
+  instance_arn = local.identity_center_instance_arn
+
+  name             = "AdministratorAccess"
+  description      = "Full administrative access."
+  session_duration = "PT12H"
+}

--- a/services/aws.tf
+++ b/services/aws.tf
@@ -1,0 +1,3 @@
+module "aws_repository" {
+  source = "../modules/aws"
+}

--- a/services/main.tf
+++ b/services/main.tf
@@ -32,6 +32,10 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = ">=5.0.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
   }
 }
 
@@ -73,4 +77,10 @@ provider "sentry" {
 
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
+}
+
+provider "aws" {
+  region     = "eu-north-1"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -221,3 +221,14 @@ variable "cloudflare_lexicon_zone_id" {
   description = "The Cloudflare Lexicon Zone ID"
   type        = string
 }
+
+variable "aws_access_key" {
+  description = "Public access key for use with AWS."
+  type        = string
+}
+
+variable "aws_secret_key" {
+  description = "Secret key for use with AWS."
+  type        = string
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,14 @@ variable "cloudflare_lexicon_zone_id" {
   description = "The Cloudflare Lexicon Zone ID"
   type        = string
 }
+
+variable "aws_access_key" {
+  description = "Public access key for use with AWS."
+  type        = string
+}
+
+variable "aws_secret_key" {
+  description = "Secret key for use with AWS."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
So we can host Lexicon with AWS eventually.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
