### PR TITLE
Add an initial database resource for the AWS Lexicon deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,4 +56,5 @@ module "services" {
   aws_access_key                             = var.aws_access_key
   aws_secret_key                             = var.aws_secret_key
   aws_instance_arn                           = var.aws_instance_arn
+  lexicon_database_password                  = var.lexicon_database_password
 }

--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+resource "aws_db_instance" "default" {
+  identifier = var.db_identifier
+
+  engine                      = "postgres"
+  engine_version              = var.postgres_version
+  allow_major_version_upgrade = true
+
+  instance_class = "db.t4g.micro"
+
+  allocated_storage = 20
+  storage_type      = "gp3"
+
+  db_name  = var.initial_db_name
+  username = var.username
+  password = var.password
+
+  backup_retention_period = 7
+
+  deletion_protection = true
+
+  publicly_accessible = false
+}

--- a/modules/aws/database/variables.tf
+++ b/modules/aws/database/variables.tf
@@ -1,0 +1,26 @@
+variable "db_identifier" {
+  description = "The database identifier"
+  type        = string
+}
+
+variable "initial_db_name" {
+  description = "The initial database name"
+  type        = string
+}
+
+variable "postgres_version" {
+  description = "The Postgres version"
+  type        = string
+  default     = "18"
+}
+
+variable "username" {
+  description = "The database user's username"
+  type        = string
+}
+
+variable "password" {
+  description = "The database user's password"
+  type        = string
+  sensitive   = true
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -34,6 +34,15 @@ module "lexicon_database" {
   default_database_name = "lexicon-prod"
 }
 
+module "lexicon_database_aws" {
+  source           = "../modules/aws/database"
+  initial_db_name  = "lexicon"
+  db_identifier    = "lexicon-prod"
+  postgres_version = "18"
+  username         = "lexicon_user"
+  password         = var.lexicon_database_password
+}
+
 module "lexicon_server" {
   source         = "../modules/render"
   name           = "Lexicon"

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -237,3 +237,9 @@ variable "aws_instance_arn" {
   description = "The AWS instance ARN to create resources under."
   type        = string
 }
+
+variable "lexicon_database_password" {
+  description = "The password for the Lexicon database."
+  type        = string
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -231,3 +231,9 @@ variable "aws_instance_arn" {
   description = "The AWS instance ARN to create resources under."
   type        = string
 }
+
+variable "lexicon_database_password" {
+  description = "The password for the Lexicon database."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
First step in the migration to AWS for hosting.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
