### PR TITLE
Add security rules to the AWS Lexicon database

### DIFF
--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -7,6 +7,15 @@ terraform {
   }
 }
 
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_security_group" "database" {
+  name   = "${var.db_identifier}-database"
+  vpc_id = data.aws_vpc.default.id
+}
+
 resource "aws_db_instance" "default" {
   identifier = var.db_identifier
 
@@ -28,4 +37,31 @@ resource "aws_db_instance" "default" {
   deletion_protection = true
 
   publicly_accessible = false
+
+  vpc_security_group_ids = [aws_security_group.database.id]
+}
+
+resource "aws_vpc_security_group_ingress_rule" "bastion_postgres" {
+  security_group_id = aws_security_group.database.id
+
+  referenced_security_group_id = var.bastion_security_group_id
+
+  from_port   = 5432
+  to_port     = 5432
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.database.id
+
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+output "endpoint" {
+  value = aws_db_instance.default.endpoint
+}
+
+output "security_group_id" {
+  value = aws_security_group.database.id
 }

--- a/modules/aws/database/variables.tf
+++ b/modules/aws/database/variables.tf
@@ -24,3 +24,8 @@ variable "password" {
   type        = string
   sensitive   = true
 }
+
+variable "bastion_security_group_id" {
+  description = "The security group ID for the associated Bastion."
+  type        = string
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -34,15 +34,6 @@ module "lexicon_database" {
   default_database_name = "lexicon-prod"
 }
 
-module "lexicon_database_aws" {
-  source           = "../modules/aws/database"
-  initial_db_name  = "lexicon"
-  db_identifier    = "lexicon-prod"
-  postgres_version = "18"
-  username         = "lexicon_user"
-  password         = var.lexicon_database_password
-}
-
 module "lexicon_bastion" {
   source = "../modules/aws/bastion"
   name   = "lexicon-bastion"
@@ -51,6 +42,17 @@ module "lexicon_bastion" {
   }
   public_ssh_key = var.public_ssh_key
 }
+
+module "lexicon_database_aws" {
+  source                    = "../modules/aws/database"
+  initial_db_name           = "lexicon"
+  db_identifier             = "lexicon-prod"
+  postgres_version          = "18"
+  username                  = "lexicon_user"
+  password                  = var.lexicon_database_password
+  bastion_security_group_id = module.lexicon_bastion.security_group_id
+}
+
 
 module "lexicon_server" {
   source         = "../modules/render"


### PR DESCRIPTION
So I can access it from the Bastion. Note that I have also renamed the Bastion so I hope that it just got renamed rather than replaced.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
