### PR TITLE
Set up the ECS container for lexicon

### DIFF
--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -65,3 +65,8 @@ output "endpoint" {
 output "security_group_id" {
   value = aws_security_group.database.id
 }
+
+output "database_url" {
+  sensitive = true
+  value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}"
+}

--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.name}-ecs-task-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_security_group" "ecs" {
+  name   = var.name
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource "aws_ecs_cluster" "default" {
+  name = var.name
+}
+
+resource "aws_ecs_task_definition" "default" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+
+  execution_role_arn = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = var.name
+      image = var.image
+
+      portMappings = [{
+        containerPort = 3000
+      }]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.default.name
+          awslogs-region        = "eu-north-1"
+          awslogs-stream-prefix = var.name
+        }
+      }
+
+      environment = [
+        for key, value in nonsensitive(var.environment_variables) : {
+          name  = key
+          value = value
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_cloudwatch_log_group" "default" {
+  name              = var.name
+  retention_in_days = 30
+}
+
+resource "aws_ecs_service" "default" {
+  name            = var.name
+  cluster         = aws_ecs_cluster.default.id
+  task_definition = aws_ecs_task_definition.default.arn
+
+  desired_count = 1
+
+  launch_type      = "FARGATE"
+  platform_version = var.fargate_version
+
+  network_configuration {
+    security_groups  = toset([aws_security_group.ecs.id])
+    subnets          = data.aws_subnets.default.ids
+    assign_public_ip = true
+  }
+}
+
+output "security_group_id" {
+  value = aws_security_group.ecs.id
+}

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -1,0 +1,33 @@
+variable "name" {
+  description = "The name of the service."
+  type        = string
+}
+
+variable "cpu" {
+  description = "Number of CPU units for the task."
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Amount of memory used by the task in MiB."
+  type        = number
+  default     = 512
+}
+
+variable "image" {
+  description = "The image to deploy."
+  type        = string
+}
+
+variable "environment_variables" {
+  description = "The environment variables for the service."
+  sensitive   = true
+  type        = map(string)
+}
+
+variable "fargate_version" {
+  description = "The Fargate version"
+  type        = string
+  default     = "1.4"
+}

--- a/modules/docker/main.tf
+++ b/modules/docker/main.tf
@@ -12,3 +12,7 @@ resource "docker_hub_repository" "default" {
   name        = var.name
   description = var.description
 }
+
+output "image_name" {
+  value = docker_hub_repository.default.id
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -1,3 +1,55 @@
+module "lexicon_bastion" {
+  source = "../modules/aws/bastion"
+  name   = "lexicon-bastion"
+  allowed_ipv4s = {
+    alex_home = "81.103.172.13/32"
+  }
+  public_ssh_key = var.public_ssh_key
+}
+
+module "lexicon_image" {
+  source      = "../modules/docker"
+  namespace   = var.docker_username
+  name        = "lexicon"
+  description = "Dockerhub repository for the Lexicon back-end server image."
+}
+
+module "lexicon_ecs_service" {
+  source = "../modules/aws/ecs"
+  name   = "lexicon"
+  image  = module.lexicon_image.image_name
+  environment_variables = {
+    DATABASE_URL         = module.lexicon_database_aws.database_url
+    NODE_ENV             = "production"
+    API_BASE_URL         = "https://${var.lexicon_domain}"
+    ALLOWED_ORIGINS      = "https://${var.lexicon_domain}"
+    GOOGLE_CLIENT_ID     = var.lexicon_google_client_id
+    GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
+    SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
+  }
+  fargate_version = "1.4"
+}
+
+module "lexicon_database_aws" {
+  source                    = "../modules/aws/database"
+  initial_db_name           = "lexicon"
+  db_identifier             = "lexicon-prod"
+  postgres_version          = "18"
+  username                  = "lexicon_user"
+  password                  = var.lexicon_database_password
+  bastion_security_group_id = module.lexicon_bastion.security_group_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ecs" {
+  security_group_id = module.lexicon_database_aws.security_group_id
+
+  referenced_security_group_id = module.lexicon_ecs_service.security_group_id
+
+  from_port   = 5432
+  to_port     = 5432
+  ip_protocol = "tcp"
+}
+
 module "lexicon_repository" {
   source      = "../modules/github/repository"
   name        = "lexicon"
@@ -34,31 +86,12 @@ module "lexicon_database" {
   default_database_name = "lexicon-prod"
 }
 
-module "lexicon_bastion" {
-  source = "../modules/aws/bastion"
-  name   = "lexicon-bastion"
-  allowed_ipv4s = {
-    alex_home = "81.103.172.13/32"
-  }
-  public_ssh_key = var.public_ssh_key
-}
-
-module "lexicon_database_aws" {
-  source                    = "../modules/aws/database"
-  initial_db_name           = "lexicon"
-  db_identifier             = "lexicon-prod"
-  postgres_version          = "18"
-  username                  = "lexicon_user"
-  password                  = var.lexicon_database_password
-  bastion_security_group_id = module.lexicon_bastion.security_group_id
-}
-
 
 module "lexicon_server" {
   source         = "../modules/render"
   name           = "Lexicon"
   repository_url = var.lexicon_repository_url
-  docker_image   = "${var.docker_username}/lexicon"
+  docker_image   = module.lexicon_image.image_name
 
   secrets = {
     DATABASE_URL         = var.lexicon_database_url
@@ -72,13 +105,6 @@ module "lexicon_server" {
 
   custom_domains    = [var.lexicon_domain]
   health_check_path = "/api/v1"
-}
-
-module "lexicon_image" {
-  source      = "../modules/docker"
-  namespace   = var.docker_username
-  name        = "lexicon"
-  description = "Dockerhub repository for the Lexicon back-end server image."
 }
 
 module "lexicon_sentry_back_end" {


### PR DESCRIPTION
Because I don't think we can actually test the database URL directly in Render as it won't be able to access it without doing some hacky stuff in AWS that I really don't want to do.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
