### PR TITLE
Rename security group

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
 }
 
 resource "aws_security_group" "ecs" {
-  name   = var.name
+  name   = "${var.name}-ecs"
   vpc_id = data.aws_vpc.default.id
 }
 

--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -46,6 +46,13 @@ resource "aws_security_group" "ecs" {
   vpc_id = data.aws_vpc.default.id
 }
 
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.ecs.id
+
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
 resource "aws_ecs_cluster" "default" {
   name = var.name
 }


### PR DESCRIPTION
# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
