### PR TITLE
Revert the rename of the security group

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
 }
 
 resource "aws_security_group" "ecs" {
-  name   = "${var.name}-ecs"
+  name   = var.name
   vpc_id = data.aws_vpc.default.id
 }
 


### PR DESCRIPTION
It was struggling to do this.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
