### PR TITLE
Use port 8080 as is currently used in Lexicon

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -72,7 +72,7 @@ resource "aws_ecs_task_definition" "default" {
       image = var.image
 
       portMappings = [{
-        containerPort = 3000
+        containerPort = var.port
       }]
 
       logConfiguration = {

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -31,3 +31,9 @@ variable "fargate_version" {
   type        = string
   default     = "1.4.0"
 }
+
+variable "port" {
+  description = "The port to use"
+  type        = number
+  default     = 8080
+}


### PR DESCRIPTION
# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
