### PR TITLE
Rename but use create-before-destroy

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -42,8 +42,12 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
 }
 
 resource "aws_security_group" "ecs" {
-  name   = var.name
+  name   = "${var.name}-ecs"
   vpc_id = data.aws_vpc.default.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_security_group_egress_rule" "all" {


### PR DESCRIPTION
This should ensure that the new security group gets created before destroying the previous one, hopefully removing all the dependencies on the old one before replacing/renaming.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
