### PR TITLE
Add create_before_destroy to all security groups

### DIFF
--- a/modules/aws/bastion/main.tf
+++ b/modules/aws/bastion/main.tf
@@ -32,6 +32,10 @@ data "aws_subnets" "default" {
 resource "aws_security_group" "bastion" {
   name   = var.name
   vpc_id = data.aws_vpc.default.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ssh" {

--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -14,6 +14,10 @@ data "aws_vpc" "default" {
 resource "aws_security_group" "database" {
   name   = "${var.db_identifier}-database"
   vpc_id = data.aws_vpc.default.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_instance" "default" {


### PR DESCRIPTION
This will make future renaming of them much easier going forward. It would need this in order to ensure that all resources get moved to the newly created one before removing the old one, therefore avoiding dependency errors.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
