### PR TITLE
Add a migration service to Lexicon

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -61,8 +61,13 @@ resource "aws_ecs_cluster" "default" {
   name = var.name
 }
 
-resource "aws_ecs_task_definition" "default" {
-  family                   = var.name
+resource "aws_ecs_task_definition" "task" {
+  for_each = {
+    for task in var.task_definitions :
+    task.name => task
+  }
+
+  family                   = "${var.name}-${each.key}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.cpu
@@ -71,8 +76,8 @@ resource "aws_ecs_task_definition" "default" {
   execution_role_arn = aws_iam_role.ecs_task_execution.arn
 
   container_definitions = jsonencode([
-    {
-      name  = var.name
+    merge({
+      name  = "${var.name}-${each.value.name}"
       image = var.image
 
       portMappings = [{
@@ -95,7 +100,11 @@ resource "aws_ecs_task_definition" "default" {
           value = value
         }
       ]
-    }
+      },
+      each.value.command == null ? {} : {
+        command = each.value.command
+      }
+    )
   ])
 }
 
@@ -107,7 +116,7 @@ resource "aws_cloudwatch_log_group" "default" {
 resource "aws_ecs_service" "default" {
   name            = var.name
   cluster         = aws_ecs_cluster.default.id
-  task_definition = aws_ecs_task_definition.default.arn
+  task_definition = aws_ecs_task_definition.task["service"].arn
 
   desired_count = 1
 

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -37,3 +37,26 @@ variable "port" {
   type        = number
   default     = 8080
 }
+
+variable "task_definitions" {
+  description = "A list of tasks to associate with the service. It **must** contain exactly one task definition named 'service'."
+  type = list(object({
+    name    = string
+    command = optional(list(string))
+  }))
+  validation {
+    condition = length([
+      for task in var.task_definitions : task
+      if task.name == "service"
+    ]) == 1
+
+    error_message = "Exactly one task definition named \"service\" is required."
+  }
+  validation {
+    condition = length(var.task_definitions) == length(distinct([
+      for task in var.task_definitions : task.name
+    ]))
+
+    error_message = "Task definition names must be unique."
+  }
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -28,6 +28,15 @@ module "lexicon_ecs_service" {
     SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
   }
   fargate_version = "1.4.0"
+
+  task_definitions = [{
+    name = "service"
+    },
+    {
+      name    = "migrate"
+      command = ["pnpm", "--dir", "apps/back-end", "run", "migrate-db"]
+    }
+  ]
 }
 
 module "lexicon_database_aws" {


### PR DESCRIPTION
This will apply the migrations to the Lexicon database on merge into main.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
