### PR TITLE
Remove remaining bits of Vercel that was only needed in the destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,8 +12,8 @@ terraform {
 
 
 module "services" {
-  source                                     = "./services"
-  vercel_api_token                           = var.vercel_api_token
+  source = "./services"
+
   github_owner                               = var.github_owner
   tfe_token                                  = var.tfe_token
   tfe_org_token                              = var.tfe_org_token

--- a/services/main.tf
+++ b/services/main.tf
@@ -8,10 +8,6 @@ terraform {
       source  = "hashicorp/tfe"
       version = ">= 0.76.1"
     }
-    vercel = {
-      source  = "vercel/vercel"
-      version = ">= 4.8"
-    }
     neon = {
       source  = "kislerdm/neon"
       version = ">= 0.13.0"
@@ -51,10 +47,6 @@ provider "github" {
 
 provider "tfe" {
   token = var.tfe_org_token
-}
-
-provider "vercel" {
-  api_token = var.vercel_api_token
 }
 
 provider "neon" {

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -226,8 +226,3 @@ variable "public_ssh_key" {
   description = "My public SSH key"
   type        = string
 }
-
-variable "vercel_api_token" {
-  type      = string
-  sensitive = true
-}

--- a/variables.tf
+++ b/variables.tf
@@ -222,8 +222,3 @@ variable "public_ssh_key" {
   description = "My public SSH key"
   type        = string
 }
-
-variable "vercel_api_token" {
-  type      = string
-  sensitive = true
-}


### PR DESCRIPTION
# Irreversible Destruction

This is a change to `infrastructure` that irreversibly destroys a managed Terraform resource. This change can **NOT** be fixed by simply reverting back the changes as it will try recreating the resource entirely and there is no guarantee that it will be restored back to the same state it was previously in.

Please take extra care before merging this one in, and be absolutely sure that you intend to fully remove the resource associated with this pull request.

Please see the commits tab of this pull request for the description of changes.
