### PR TITLE
Set up OIDC for the connection between GitHub Actions and AWS

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -133,3 +133,22 @@ resource "aws_ecs_service" "default" {
 output "security_group_id" {
   value = aws_security_group.ecs.id
 }
+
+output "execution_role_arn" {
+  value = aws_iam_role.ecs_task_execution.arn
+}
+
+output "cluster_name" {
+  value = aws_ecs_cluster.default.name
+}
+
+output "service_name" {
+  value = aws_ecs_service.default.name
+}
+
+output "task_families" {
+  value = {
+    for name, task in aws_ecs_task_definition.task :
+    name => task.family
+  }
+}

--- a/modules/aws/github_role/main.tf
+++ b/modules/aws/github_role/main.tf
@@ -1,0 +1,61 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "github_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+
+    principals {
+      type = "Federated"
+
+      identifiers = [
+        var.oidc_provider_arn
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+
+      values = [
+        "repo:${var.repository}:ref:refs/heads/main"
+      ]
+    }
+  }
+}
+
+
+
+resource "aws_iam_role" "role" {
+  name = var.role_name
+
+  assume_role_policy = data.aws_iam_policy_document.github_assume_role.json
+}
+
+resource "aws_iam_role_policy" "role" {
+  role   = aws_iam_role.role.id
+  policy = var.policy_json
+}
+
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/modules/aws/github_role/variables.tf
+++ b/modules/aws/github_role/variables.tf
@@ -1,0 +1,19 @@
+variable "repository" {
+  description = "The GitHub repository, structured as owner/repo."
+  type        = string
+}
+
+variable "role_name" {
+  description = "The IAM role name."
+  type        = string
+}
+
+variable "oidc_provider_arn" {
+  description = "The OIDC provider ARN."
+  type        = string
+}
+
+variable "policy_json" {
+  description = "The IAM policy to attach."
+  type        = string
+}

--- a/services/github_aws_oidc_provider.tf
+++ b/services/github_aws_oidc_provider.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com"
+  ]
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -49,6 +49,43 @@ module "lexicon_database_aws" {
   bastion_security_group_id = module.lexicon_bastion.security_group_id
 }
 
+data "aws_iam_policy_document" "lexicon_deploy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTaskDefinition",
+      "ecs:UpdateService",
+      "ecs:RunTask",
+      "ecs:DescribeTasks",
+      "ecs:DescribeClusters"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [
+      module.lexicon_ecs_service.execution_role_arn
+    ]
+  }
+}
+
+module "lexicon_deployment_role" {
+  source            = "../modules/aws/github_role"
+  repository        = "alextheman231/lexicon"
+  role_name         = "lexicon-deployment"
+  oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  policy_json       = data.aws_iam_policy_document.lexicon_deploy.json
+}
+
 resource "aws_vpc_security_group_ingress_rule" "ecs" {
   security_group_id = module.lexicon_database_aws.security_group_id
 
@@ -76,6 +113,7 @@ module "lexicon_repository" {
     DOCKER_PAT        = var.docker_pat_lexicon_encrypted
   }
   variables = {
+    AWS_ROLE_ARN         = module.lexicon_deployment_role.role_arn
     VITE_API_BASE_URL    = "https://${var.lexicon_api_domain}"
     RENDER_SERVICE_ID    = var.lexicon_render_service_id
     DOCKER_USERNAME      = var.docker_username


### PR DESCRIPTION
I think this is better and more secure than an access key/secret key, and it seems to be what AWS tends to recommend. Eventually I would like to move this repository to use OIDC with AWS too, but that's for another time.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
