### PR TITLE
Add the security group ID and subnet IDs for use in the run-task step

### DIFF
--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -18,6 +18,14 @@ data "aws_subnets" "default" {
   }
 }
 
+locals {
+  network_configuration = {
+    security_groups  = toset([aws_security_group.ecs.id])
+    subnets          = data.aws_subnets.default.ids
+    assign_public_ip = true
+  }
+}
+
 resource "aws_iam_role" "ecs_task_execution" {
   name = "${var.name}-ecs-task-execution"
 
@@ -124,9 +132,9 @@ resource "aws_ecs_service" "default" {
   platform_version = var.fargate_version
 
   network_configuration {
-    security_groups  = toset([aws_security_group.ecs.id])
-    subnets          = data.aws_subnets.default.ids
-    assign_public_ip = true
+    security_groups  = local.network_configuration.security_groups
+    subnets          = local.network_configuration.subnets
+    assign_public_ip = local.network_configuration.assign_public_ip
   }
 }
 
@@ -151,4 +159,12 @@ output "task_families" {
     for name, task in aws_ecs_task_definition.task :
     name => task.family
   }
+}
+
+output "subnet_ids" {
+  value = local.network_configuration.subnets
+}
+
+output "assign_public_ip" {
+  value = local.network_configuration.assign_public_ip
 }

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -118,6 +118,9 @@ module "lexicon_repository" {
     AWS_SERVICE_NAME          = module.lexicon_ecs_service.service_name
     AWS_MIGRATION_TASK_FAMILY = module.lexicon_ecs_service.task_families["migrate"]
     AWS_REGION                = local.aws_region
+    AWS_SECURITY_GROUP_ID     = module.lexicon_ecs_service.security_group_id
+    AWS_SUBNET_IDS            = join(",", module.lexicon_ecs_service.subnet_ids)
+    AWS_ASSIGN_PUBLIC_IP      = module.lexicon_ecs_service.assign_public_ip ? "ENABLED" : "DISABLED"
     VITE_API_BASE_URL         = "https://${var.lexicon_api_domain}"
     RENDER_SERVICE_ID         = var.lexicon_render_service_id
     DOCKER_USERNAME           = var.docker_username


### PR DESCRIPTION
# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
