### PR TITLE
Use sslmode=verifyfull

### DIFF
--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -72,5 +72,5 @@ output "security_group_id" {
 
 output "database_url" {
   sensitive = true
-  value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}?sslmode=require"
+  value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}?sslmode=verify-full"
 }


### PR DESCRIPTION
sslmode=require is actually deprecated in favour of this, so let's use that instead.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
