### PR TITLE
Remove sslmode from database URL

### DIFF
--- a/modules/aws/database/main.tf
+++ b/modules/aws/database/main.tf
@@ -72,5 +72,5 @@ output "security_group_id" {
 
 output "database_url" {
   sensitive = true
-  value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}?sslmode=verify-full"
+  value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}"
 }


### PR DESCRIPTION
The app is now configuring the SSL options so it might not be needed.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
