### PR TITLE
Add the load balancer for the ECS deployment

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -173,26 +173,3 @@ provider "registry.terraform.io/render-oss/render" {
     "zh:f1a7ad3096a8abc690c4c76341d94c3d56bb71bd65ac2842b610b515a0fbd72b",
   ]
 }
-
-provider "registry.terraform.io/vercel/vercel" {
-  version     = "5.3.0"
-  constraints = ">= 4.8.0"
-  hashes = [
-    "h1:6Xf/dJya2q8N/kte7WLzjgUM7azTV6nRv+wf6uHfa7w=",
-    "h1:Zg61UQ3pqL1w+Goe70lnKIwXu6Sf4OOzkAeWb9aSI1I=",
-    "zh:23216fea1c6c78df34acce4f614ae4251565be05e596bdb24ff6d508fb943b15",
-    "zh:36c6551cba94d1f55ae8d1764f2ad0cce4e60ffb32b1864b66999cc21be001fc",
-    "zh:475126a8af664eb6859eb1146fa98151950b2240613711084ab99bf88dbc4de6",
-    "zh:6af644dcc277420eceb69084d152d9bae9664564b63f32f5ecea61c6ed87d6d3",
-    "zh:7ed6a690245915a8ed47c114c7577d8a65d0f64c00a85fb8ae501d931d82e458",
-    "zh:8da5dc126f8248173e31dbf2afa79e1ad5ca82f4d94477fd6e30b38f41f5e230",
-    "zh:90067042343773ce4505ab13fbfcfaad9165f4d018a6bdfb02c7f46f69162365",
-    "zh:a09598700601f8b665bd2386ed0f02755ccafcded77fd12a9eb40630d9616eb1",
-    "zh:b4fbd44d3252dc23c3db593da9b099178fa548d51befc887e8e8e3a466bfdf81",
-    "zh:d3774d8a3730cc7f46c335cce11b0363baf134884d606349814cc556a7d0a8fc",
-    "zh:d723caa486b7dc5a0e21d63f54cfd0cfef989a385c7f76ba7d7b5365054eacb6",
-    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
-    "zh:f3a44243f9c1363a661d83629348b5c116f58fb58e33a06bd3bd608ce29f2aa8",
-    "zh:ff9dd42ceb0f75ef1d6637faf31ba89435a39b4079f5e13161a08f72ed613545",
-  ]
-}

--- a/modules/aws/alb/main.tf
+++ b/modules/aws/alb/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name   = "${var.name}-alb"
+  vpc_id = data.aws_vpc.default.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.alb.id
+
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.alb.id
+
+  from_port   = 80
+  to_port     = 80
+  ip_protocol = "tcp"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.alb.id
+
+  from_port   = 443
+  to_port     = 443
+  ip_protocol = "tcp"
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+resource "aws_lb_target_group" "default" {
+  name        = "${var.name}-target-group"
+  target_type = "ip"
+  vpc_id      = data.aws_vpc.default.id
+
+  port     = var.port
+  protocol = "HTTP"
+
+  health_check {
+    path     = var.health_check_path
+    protocol = "HTTP"
+    matcher  = "200"
+  }
+}
+
+resource "aws_lb" "default" {
+  name               = var.name
+  security_groups    = [aws_security_group.alb.id]
+  load_balancer_type = "application"
+  subnets            = data.aws_subnets.default.ids
+}
+
+resource "aws_lb_listener" "default" {
+  load_balancer_arn = aws_lb.default.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.default.arn
+  }
+}

--- a/modules/aws/alb/outputs.tf
+++ b/modules/aws/alb/outputs.tf
@@ -1,0 +1,11 @@
+output "security_group_id" {
+  value = aws_security_group.alb.id
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.default.arn
+}
+
+output "listener_arn" {
+  value = aws_lb_listener.default.arn
+}

--- a/modules/aws/alb/variables.tf
+++ b/modules/aws/alb/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "The name of the Load balancer."
+  type        = string
+}
+
+variable "port" {
+  description = "The port to use."
+  type        = number
+  default     = 8080
+}
+
+variable "health_check_path" {
+  description = "The path to run the health check on."
+  type        = string
+}

--- a/modules/aws/ecs/main.tf
+++ b/modules/aws/ecs/main.tf
@@ -136,35 +136,10 @@ resource "aws_ecs_service" "default" {
     subnets          = local.network_configuration.subnets
     assign_public_ip = local.network_configuration.assign_public_ip
   }
-}
 
-output "security_group_id" {
-  value = aws_security_group.ecs.id
-}
-
-output "execution_role_arn" {
-  value = aws_iam_role.ecs_task_execution.arn
-}
-
-output "cluster_name" {
-  value = aws_ecs_cluster.default.name
-}
-
-output "service_name" {
-  value = aws_ecs_service.default.name
-}
-
-output "task_families" {
-  value = {
-    for name, task in aws_ecs_task_definition.task :
-    name => task.family
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "${var.name}-service"
+    container_port   = var.port
   }
-}
-
-output "subnet_ids" {
-  value = local.network_configuration.subnets
-}
-
-output "assign_public_ip" {
-  value = local.network_configuration.assign_public_ip
 }

--- a/modules/aws/ecs/outputs.tf
+++ b/modules/aws/ecs/outputs.tf
@@ -1,0 +1,30 @@
+output "security_group_id" {
+  value = aws_security_group.ecs.id
+}
+
+output "execution_role_arn" {
+  value = aws_iam_role.ecs_task_execution.arn
+}
+
+output "cluster_name" {
+  value = aws_ecs_cluster.default.name
+}
+
+output "service_name" {
+  value = aws_ecs_service.default.name
+}
+
+output "task_families" {
+  value = {
+    for name, task in aws_ecs_task_definition.task :
+    name => task.family
+  }
+}
+
+output "subnet_ids" {
+  value = local.network_configuration.subnets
+}
+
+output "assign_public_ip" {
+  value = local.network_configuration.assign_public_ip
+}

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -38,6 +38,16 @@ variable "port" {
   default     = 8080
 }
 
+variable "target_group_arn" {
+  description = "The target group ARN."
+  type        = string
+}
+
+variable "lb_listener_arn" {
+  description = "The load balancer listener ARN."
+  type        = string
+}
+
 variable "task_definitions" {
   description = "A list of tasks to associate with the service. It **must** contain exactly one task definition named 'service'."
   type = list(object({

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -1,3 +1,7 @@
+locals {
+  backend_port = 8080
+}
+
 module "lexicon_bastion" {
   source = "../modules/aws/bastion"
   name   = "lexicon-bastion"
@@ -14,10 +18,28 @@ module "lexicon_image" {
   description = "Dockerhub repository for the Lexicon back-end server image."
 }
 
+module "lexicon_database_aws" {
+  source                    = "../modules/aws/database"
+  initial_db_name           = "lexicon"
+  db_identifier             = "lexicon-prod"
+  postgres_version          = "18"
+  username                  = "lexicon_user"
+  password                  = var.lexicon_database_password
+  bastion_security_group_id = module.lexicon_bastion.security_group_id
+}
+
+module "lexicon_load_balancer" {
+  source            = "../modules/aws/alb"
+  name              = "lexicon"
+  health_check_path = "/api/v1"
+  port              = local.backend_port
+}
+
 module "lexicon_ecs_service" {
   source = "../modules/aws/ecs"
   name   = "lexicon"
   image  = module.lexicon_image.image_name
+  port   = local.backend_port
   environment_variables = {
     DATABASE_URL         = module.lexicon_database_aws.database_url
     NODE_ENV             = "production"
@@ -37,16 +59,9 @@ module "lexicon_ecs_service" {
       command = ["pnpm", "--dir", "apps/back-end", "run", "migrate-db"]
     }
   ]
-}
 
-module "lexicon_database_aws" {
-  source                    = "../modules/aws/database"
-  initial_db_name           = "lexicon"
-  db_identifier             = "lexicon-prod"
-  postgres_version          = "18"
-  username                  = "lexicon_user"
-  password                  = var.lexicon_database_password
-  bastion_security_group_id = module.lexicon_bastion.security_group_id
+  target_group_arn = module.lexicon_load_balancer.target_group_arn
+  lb_listener_arn  = module.lexicon_load_balancer.listener_arn
 }
 
 data "aws_iam_policy_document" "lexicon_deploy" {
@@ -93,6 +108,16 @@ resource "aws_vpc_security_group_ingress_rule" "ecs" {
 
   from_port   = 5432
   to_port     = 5432
+  ip_protocol = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb" {
+  security_group_id = module.lexicon_ecs_service.security_group_id
+
+  referenced_security_group_id = module.lexicon_load_balancer.security_group_id
+
+  from_port   = local.backend_port
+  to_port     = local.backend_port
   ip_protocol = "tcp"
 }
 


### PR DESCRIPTION
This will be needed in configuring our domain so its DNS records point to our AWS deployment. We are so nearly there now!

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
