### PR TITLE
Add the ACM certificate resource and give Lexicon a certificate

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "5.21.1"
   constraints = ">= 5.0.0"
   hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
     "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
     "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
     "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
@@ -39,6 +40,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.51.0"
   hashes = [
     "h1:Dg9X3Gde96OCT3TovLKAKumnR64VqIIQ37m/9NRJ00Y=",
+    "h1:lpXqosKH8yAahK3SA1P5Pdy1ziXJcY+blUidY0q9yGk=",
     "zh:1ab1d78f2336fed42b4e13fa0077a0be9d86a7899897cda5b9f1a60051ec2e93",
     "zh:1df11f5f252030803939a1c778931dbdcee1b1070b38b98d9a8cbfc26c2aeb8e",
     "zh:20ec9af03c0c1f2f8582a8805d43a4cd1a0a65082308e00f025d87605715a88f",
@@ -107,6 +109,7 @@ provider "registry.terraform.io/jianyuan/sentry" {
   constraints = ">= 0.14.3"
   hashes = [
     "h1:P/L0PO1PQUDqRYh9qO9gUzb7BjI3tQ1XASCP5mhaYTo=",
+    "h1:lCw8kDiDbXxj1TuDCgobuxLj/caAdPuuaFgoiVAuF00=",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
     "zh:113afe9d009f7f33911f9f0cc7c590c21d3d2a25ed7538b861ef313bb42f4baf",
     "zh:13e76deb68bec23a41c949339181ef1b7b74efe8ccfb592f02bfb9fac6ec4ff9",

--- a/modules/aws/acm_certificate/main.tf
+++ b/modules/aws/acm_certificate/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}

--- a/modules/aws/acm_certificate/outputs.tf
+++ b/modules/aws/acm_certificate/outputs.tf
@@ -1,0 +1,7 @@
+output "domain_validation_options" {
+  value = aws_acm_certificate.default.domain_validation_options
+}
+
+output "certificate_arn" {
+  value = aws_acm_certificate.default.arn
+}

--- a/modules/aws/acm_certificate/resources.tf
+++ b/modules/aws/acm_certificate/resources.tf
@@ -1,0 +1,9 @@
+resource "aws_acm_certificate" "default" {
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
+  validation_method         = var.validation_method
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/aws/acm_certificate/variables.tf
+++ b/modules/aws/acm_certificate/variables.tf
@@ -1,0 +1,16 @@
+variable "domain_name" {
+  description = "Domain name for which the certificate should be issued."
+  type        = string
+}
+
+variable "validation_method" {
+  description = "Which method to use for validation. Can be either DNS or EMAIL."
+  type        = string
+  default     = "DNS"
+}
+
+variable "subject_alternative_names" {
+  description = "Set of domains that should be SANs in the issued certificate."
+  type        = list(string)
+  default     = []
+}

--- a/modules/aws/alb/main.tf
+++ b/modules/aws/alb/main.tf
@@ -74,10 +74,30 @@ resource "aws_lb" "default" {
   subnets            = data.aws_subnets.default.ids
 }
 
-resource "aws_lb_listener" "default" {
+resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.default.arn
-  port              = 80
-  protocol          = "HTTP"
+
+  port     = 80
+  protocol = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      protocol    = "HTTPS"
+      port        = "443"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.default.arn
+  port              = 443
+  protocol          = "HTTPS"
+
+  ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn = var.certificate_arn
 
   default_action {
     type             = "forward"

--- a/modules/aws/alb/outputs.tf
+++ b/modules/aws/alb/outputs.tf
@@ -7,5 +7,13 @@ output "target_group_arn" {
 }
 
 output "listener_arn" {
-  value = aws_lb_listener.default.arn
+  value = aws_lb_listener.https.arn
+}
+
+output "dns_name" {
+  value = aws_lb.default.dns_name
+}
+
+output "zone_id" {
+  value = aws_lb.default.zone_id
 }

--- a/modules/aws/alb/variables.tf
+++ b/modules/aws/alb/variables.tf
@@ -13,3 +13,8 @@ variable "health_check_path" {
   description = "The path to run the health check on."
   type        = string
 }
+
+variable "certificate_arn" {
+  description = "ARN of the default SSL server certificate."
+  type        = string
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -28,11 +28,18 @@ module "lexicon_database_aws" {
   bastion_security_group_id = module.lexicon_bastion.security_group_id
 }
 
+module "lexicon_acm_certificate" {
+  source                    = "../modules/aws/acm_certificate"
+  domain_name               = var.lexicon_domain
+  subject_alternative_names = ["www.${var.lexicon_domain}"]
+}
+
 module "lexicon_load_balancer" {
   source            = "../modules/aws/alb"
   name              = "lexicon"
   health_check_path = "/api/v1"
   port              = local.backend_port
+  certificate_arn   = module.lexicon_acm_certificate.certificate_arn
 }
 
 module "lexicon_ecs_service" {


### PR DESCRIPTION
After this, we will need to validate the DNS, I think. I think it needs to be done in separate steps so the certificate is definitely created before we configure DNS.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
