### PR TITLE
Add the app-level DNS records so lexiconblogs.com can actually work

### DIFF
--- a/modules/cloudflare/dns/main.tf
+++ b/modules/cloudflare/dns/main.tf
@@ -13,4 +13,5 @@ resource "cloudflare_dns_record" "default" {
   type    = var.type
   zone_id = var.zone_id
   content = var.content
+  proxied = var.proxied
 }

--- a/modules/cloudflare/dns/variables.tf
+++ b/modules/cloudflare/dns/variables.tf
@@ -24,3 +24,9 @@ variable "content" {
   type        = string
   default     = null
 }
+
+variable "proxied" {
+  description = "Whether the record is receiving the performance and security benefits of Cloudflare."
+  type        = bool
+  default     = true
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -34,7 +34,7 @@ module "lexicon_acm_certificate" {
   subject_alternative_names = ["www.${var.lexicon_domain}"]
 }
 
-module "lexicon_dns_records" {
+module "lexicon_dns_validation_records" {
   for_each = {
     for option in module.lexicon_acm_certificate.domain_validation_options :
     option.domain_name => option
@@ -47,6 +47,12 @@ module "lexicon_dns_records" {
   content = each.value.resource_record_value
 
   zone_id = var.cloudflare_lexicon_zone_id
+  proxied = false
+}
+
+moved {
+  from = module.lexicon_dns_records
+  to   = module.lexicon_dns_validation_records
 }
 
 module "lexicon_acm_certificate_validation" {
@@ -54,7 +60,7 @@ module "lexicon_acm_certificate_validation" {
 
   certificate_arn = module.lexicon_acm_certificate.certificate_arn
   validation_record_fqdns = [
-    for record in module.lexicon_dns_records :
+    for record in module.lexicon_dns_validation_records :
     record.fqdn
   ]
 }
@@ -65,6 +71,24 @@ module "lexicon_load_balancer" {
   health_check_path = "/api/v1"
   port              = local.backend_port
   certificate_arn   = module.lexicon_acm_certificate_validation.validated_certificate_arn
+}
+
+module "lexicon_dns_record" {
+  source = "../modules/cloudflare/dns"
+
+  name    = var.lexicon_domain
+  type    = "CNAME"
+  zone_id = var.cloudflare_lexicon_zone_id
+  content = module.lexicon_load_balancer.dns_name
+}
+
+module "lexicon_dns_record_www" {
+  source = "../modules/cloudflare/dns"
+
+  name    = "www.${var.lexicon_domain}"
+  type    = "CNAME"
+  zone_id = var.cloudflare_lexicon_zone_id
+  content = module.lexicon_load_balancer.dns_name
 }
 
 module "lexicon_ecs_service" {


### PR DESCRIPTION
Now this should finish it. Let's do this.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
