### PR TITLE
Reapply "Normalise the name and content on the DNS records"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,20 +81,27 @@ jobs:
       - name: Save plan output
         run: |
           awk '
-          /Note: Objects have changed outside of Terraform/ ||
-          /Terraform used the selected providers to generate the following execution/ ||
-          /Terraform will perform the following actions:/ ||
-          /No changes\. Your infrastructure matches the configuration\./ {
-            printing = 1
+          /^Note: Objects have changed outside of Terraform$/ {
+              printing=1
           }
 
-           /^─────────────────────────────────────────────────────────────────────────────$/ {
-            if (printing) {
-              exit
-            }
+          /^Terraform used the selected providers to generate the following execution/ {
+              printing=1
+          }
+
+          /^No changes\. Your infrastructure matches the configuration\./ {
+              printing=1
           }
 
           printing
+
+          /^Plan:/ {
+              plan_seen=1
+          }
+
+          plan_seen && /^─────────────────────────────────────────────────────────────────────────────$/ {
+              exit
+          }
           ' raw-plan.md > plan.md
 
       - name: Save plan summary

--- a/modules/cloudflare/dns/main.tf
+++ b/modules/cloudflare/dns/main.tf
@@ -8,10 +8,17 @@ terraform {
 }
 
 resource "cloudflare_dns_record" "default" {
-  name    = var.name
+  name = contains(["CNAME", "MX", "NS"], var.type) ? trimsuffix(var.name, ".") : var.name
+
   ttl     = var.ttl
   type    = var.type
   zone_id = var.zone_id
-  content = var.content
+  content = (
+    var.type == "TXT"
+    ? join(" ", formatlist("\"%s\"", regexall("(?s).{1,255}", var.content)))
+    : contains(["CNAME", "MX", "NS"], var.type)
+    ? trimsuffix(var.content, ".")
+    : var.content
+  )
   proxied = var.proxied
 }


### PR DESCRIPTION
This reverts commit b01e886c83ee6d8d884a18d77f14d4b8e3d2ce42.

The plan for this one is expected to have the objects changed outside of Terraform block. This commit will then fix it for future plans.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
