### PR TITLE
Add the secret manager to Lexicon

### DIFF
--- a/modules/aws/ecs/resources.tf
+++ b/modules/aws/ecs/resources.tf
@@ -21,6 +21,27 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
+  count = length(var.secret_arns) > 0 ? 1 : 0
+
+  name = "${var.name}-ecs-task-execution-secrets"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+
+      Resource = distinct(values(var.secret_arns))
+    }]
+  })
+}
+
 resource "aws_security_group" "ecs" {
   name   = "${var.name}-ecs"
   vpc_id = data.aws_vpc.default.id
@@ -75,11 +96,19 @@ resource "aws_ecs_task_definition" "task" {
       }
 
       environment = [
-        for key, value in nonsensitive(var.environment_variables) : {
+        for key, value in var.environment_variables : {
           name  = key
           value = value
         }
       ]
+      },
+      length(var.secret_arns) == 0 ? {} : {
+        secrets = [
+          for key, arn in var.secret_arns : {
+            name      = key
+            valueFrom = "${arn}:${key}::"
+          }
+        ]
       },
       each.value.command == null ? {} : {
         command = each.value.command

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -22,7 +22,11 @@ variable "image" {
 
 variable "environment_variables" {
   description = "The environment variables for the service."
-  sensitive   = true
+  type        = map(string)
+}
+
+variable "secret_arns" {
+  description = "Mapping of secret environment variable names to AWS Secrets Manager ARNs."
   type        = map(string)
 }
 

--- a/modules/aws/secrets_manager/main.tf
+++ b/modules/aws/secrets_manager/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}

--- a/modules/aws/secrets_manager/outputs.tf
+++ b/modules/aws/secrets_manager/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "ARN of the secret."
+  value       = aws_secretsmanager_secret.default.arn
+}

--- a/modules/aws/secrets_manager/resources.tf
+++ b/modules/aws/secrets_manager/resources.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "default" {
+  name = var.name
+}
+
+resource "aws_secretsmanager_secret_version" "default" {
+  secret_id     = aws_secretsmanager_secret.default.id
+  secret_string = jsonencode(var.secrets)
+}

--- a/modules/aws/secrets_manager/variables.tf
+++ b/modules/aws/secrets_manager/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "The secret manager name."
+  type        = string
+}
+
+variable "secrets" {
+  description = "The secrets to use."
+  type        = map(string)
+  sensitive   = true
+}

--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -11,13 +11,15 @@ module "lexicon_ecs_service" {
   image  = module.lexicon_image.image_name
   port   = local.backend_port
   environment_variables = {
-    DATABASE_URL         = module.lexicon_database_aws.database_url
-    NODE_ENV             = "production"
-    API_BASE_URL         = "https://${var.lexicon_domain}"
-    ALLOWED_ORIGINS      = "https://${var.lexicon_domain}"
-    GOOGLE_CLIENT_ID     = var.lexicon_google_client_id
-    GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
-    SENTRY_DSN           = var.lexicon_back_end_sentry_dsn
+    NODE_ENV         = "production"
+    API_BASE_URL     = "https://${var.lexicon_domain}"
+    ALLOWED_ORIGINS  = "https://${var.lexicon_domain}"
+    GOOGLE_CLIENT_ID = var.lexicon_google_client_id
+    SENTRY_DSN       = var.lexicon_back_end_sentry_dsn
+  }
+  secret_arns = {
+    DATABASE_URL         = module.lexicon_secrets.arn
+    GOOGLE_CLIENT_SECRET = module.lexicon_secrets.arn
   }
   fargate_version = "1.4.0"
 

--- a/services/lexicon/secrets.tf
+++ b/services/lexicon/secrets.tf
@@ -1,0 +1,8 @@
+module "lexicon_secrets" {
+  source = "../../modules/aws/secrets_manager"
+  name   = "lexicon"
+  secrets = {
+    DATABASE_URL         = module.lexicon_database_aws.database_url
+    GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
+  }
+}


### PR DESCRIPTION
So we don't expose secrets in the plaintext environment variables.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
