### PR TITLE
Consider the Note section as something that ends the plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           printing
 
-          /^Plan:/ {
+          /^(Plan:|Note:)/ {
               plan_seen=1
           }
 


### PR DESCRIPTION
Otherwise on no changes, we see the note section.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
