### PR TITLE
Change the plan end text for no changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           printing
 
-          /^(Plan:|Note:)/ {
+          /^(Plan:|and found no differences\, so no changes are needed\.)/ {
               plan_seen=1
           }
 


### PR DESCRIPTION
# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
