### PR TITLE
Remove PNPM cache from new apply workflows

### DIFF
--- a/.github/workflows/change-request.yml
+++ b/.github/workflows/change-request.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: "pnpm"
 
       - name: Install alex-c-line
         uses: alextheman231/typescript-actions/actions/safe-npm-dependency-global-install@8701899e25ea05979ebb0c89da71c4ebd6c3911d # v1.2.3

--- a/.github/workflows/scheduled-apply.yml
+++ b/.github/workflows/scheduled-apply.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: "pnpm"
 
       - name: Install alex-c-line
         uses: alextheman231/typescript-actions/actions/safe-npm-dependency-global-install@8701899e25ea05979ebb0c89da71c4ebd6c3911d # v1.2.3


### PR DESCRIPTION
They don't need it.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
