### PR TITLE
Give sensible defaults for the reason and description

### DIFF
--- a/.github/workflows/change-request.yml
+++ b/.github/workflows/change-request.yml
@@ -6,10 +6,11 @@ on:
       reason:
         description: A short explanation for the reason behind the change.
         required: true
+        default: Reapply the configuration
       description:
         description: A further description of the change.
         required: false
-        default: Reapply the configuration
+        default: Trigger a Terraform apply.
 
 jobs:
   create-change-request:

--- a/.github/workflows/scheduled-apply.yml
+++ b/.github/workflows/scheduled-apply.yml
@@ -3,8 +3,6 @@ name: Scheduled Apply
 on:
   schedule:
     - cron: 0 21 1 * *
-  # TODO: Remove after testing
-  workflow_dispatch:
 
 jobs:
   scheduled-apply:


### PR DESCRIPTION
The user will still have to enter them, but these are sensible enough defaults that they can change if they want.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
