### PR TITLE
Remove the Sentry organisation ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,6 @@ module "services" {
   webhook_url                                = var.webhook_url
   docker_pat_lexicon_encrypted               = var.docker_pat_lexicon_encrypted
   sentry_infrastructure_token                = var.sentry_infrastructure_token
-  sentry_organisation_id                     = var.sentry_organisation_id
   sentry_organisation_token                  = var.sentry_organisation_token
   cloudflare_api_token                       = var.cloudflare_api_token
   cloudflare_lexicon_zone_id                 = var.cloudflare_lexicon_zone_id

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -107,11 +107,6 @@ variable "sentry_infrastructure_token" {
   sensitive   = true
 }
 
-variable "sentry_organisation_id" {
-  description = "ID of the Sentry organisation"
-  type        = string
-}
-
 variable "sentry_organisation_token" {
   description = "Sentry organisation token to use in GitHub Actions. This has been encrypted with respect to the alextheman231 GitHub organisation."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -106,10 +106,6 @@ variable "sentry_infrastructure_token" {
   sensitive = true
 }
 
-variable "sentry_organisation_id" {
-  type = string
-}
-
 variable "sentry_organisation_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
We now get it from the organisation directly.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
