### PR TITLE
Add OIDC for the AWS/Terraform connection

### DIFF
--- a/modules/aws/terraform_role/outputs.tf
+++ b/modules/aws/terraform_role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_name" {
+  value = aws_iam_role.role.name
+}
+
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}

--- a/modules/aws/terraform_role/resources.tf
+++ b/modules/aws/terraform_role/resources.tf
@@ -5,10 +5,8 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_role_policy" "role" {
+  count = var.policy_json == null ? 0 : 1
+
   role   = aws_iam_role.role.id
   policy = var.policy_json
-}
-
-output "role_arn" {
-  value = aws_iam_role.role.arn
 }

--- a/modules/aws/terraform_role/variables.tf
+++ b/modules/aws/terraform_role/variables.tf
@@ -33,6 +33,7 @@ variable "oidc_provider_arn" {
 }
 
 variable "policy_json" {
-  description = "The IAM policy to attach."
-  type        = string
+  type     = string
+  nullable = true
+  default  = null
 }

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -27,30 +27,6 @@ module "infrastructure_repository" {
   labels = merge(local.labels.standard, local.labels.infrastructure)
 }
 
-data "aws_iam_policy_document" "terraform_plan" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "Describe*",
-      "List*",
-      "Get*"
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:PassRole"
-    ]
-
-    resources = ["*"]
-  }
-}
-
 module "terraform_plan_role" {
   source = "../modules/aws/terraform_role"
 
@@ -59,36 +35,13 @@ module "terraform_plan_role" {
   project           = module.infrastructure_workspace.project_name
   workspace         = module.infrastructure_workspace.workspace_name
 
-  role_name   = "terraform-plan"
-  run_phase   = "plan"
-  policy_json = data.aws_iam_policy_document.terraform_plan.json
+  role_name = "terraform-plan"
+  run_phase = "plan"
 }
 
-data "aws_iam_policy_document" "terraform_apply" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "Describe*",
-      "List*",
-      "Get*",
-      "Create*",
-      "Update*",
-      "Delete*"
-    ]
-
-    resources = ["*"]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "iam:PassRole"
-    ]
-
-    resources = ["*"]
-  }
+resource "aws_iam_role_policy_attachment" "readonly" {
+  role       = module.terraform_plan_role.role_name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 module "terraform_apply_role" {
@@ -99,7 +52,11 @@ module "terraform_apply_role" {
   project           = module.infrastructure_workspace.project_name
   workspace         = module.infrastructure_workspace.workspace_name
 
-  role_name   = "terraform-apply"
-  run_phase   = "apply"
-  policy_json = data.aws_iam_policy_document.terraform_apply.json
+  role_name = "terraform-apply"
+  run_phase = "apply"
+}
+
+resource "aws_iam_role_policy_attachment" "administrator" {
+  role       = module.terraform_apply_role.role_name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }


### PR DESCRIPTION
This will hopefully mean less secrets to maintain - namely the AWS access key and secret key.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
