### PR TITLE
Add OIDC configurations for HCP Terraform

### DIFF
--- a/modules/tfe/aws_oidc/main.tf
+++ b/modules/tfe/aws_oidc/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = ">= 0.76.1"
+    }
+  }
+}

--- a/modules/tfe/aws_oidc/outputs.tf
+++ b/modules/tfe/aws_oidc/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = tfe_aws_oidc_configuration.default.id
+}

--- a/modules/tfe/aws_oidc/resources.tf
+++ b/modules/tfe/aws_oidc/resources.tf
@@ -1,0 +1,4 @@
+resource "tfe_aws_oidc_configuration" "default" {
+  role_arn     = var.role_arn
+  organization = var.organisation_name
+}

--- a/modules/tfe/aws_oidc/variables.tf
+++ b/modules/tfe/aws_oidc/variables.tf
@@ -1,0 +1,9 @@
+variable "role_arn" {
+  description = "The AWS ARN of your role."
+  type        = string
+}
+
+variable "organisation_name" {
+  description = "The name of the organisation."
+  type        = string
+}

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -43,6 +43,11 @@ resource "aws_iam_role_policy_attachment" "readonly" {
   role       = module.terraform_plan_role.role_name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
+module "terraform_plan_oidc_configuration" {
+  source            = "../modules/tfe/aws_oidc"
+  role_arn          = module.terraform_plan_role.role_arn
+  organisation_name = module.tfe_organisation.organisation_name
+}
 
 module "terraform_apply_role" {
   source = "../modules/aws/terraform_role"
@@ -59,4 +64,10 @@ module "terraform_apply_role" {
 resource "aws_iam_role_policy_attachment" "administrator" {
   role       = module.terraform_apply_role.role_name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+module "terraform_apply_oidc_configuration" {
+  source            = "../modules/tfe/aws_oidc"
+  role_arn          = module.terraform_apply_role.role_arn
+  organisation_name = module.tfe_organisation.organisation_name
 }


### PR DESCRIPTION
If this works, we can remove our AWS access keys and secret keys.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
