### PR TITLE
Remove the manual AWS keys

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,6 @@ module "services" {
   sentry_organisation_token                  = var.sentry_organisation_token
   cloudflare_api_token                       = var.cloudflare_api_token
   cloudflare_lexicon_zone_id                 = var.cloudflare_lexicon_zone_id
-  aws_access_key                             = var.aws_access_key
-  aws_secret_key                             = var.aws_secret_key
   lexicon_database_password                  = var.lexicon_database_password
   public_ssh_key                             = var.public_ssh_key
 }

--- a/services/main.tf
+++ b/services/main.tf
@@ -55,7 +55,5 @@ provider "cloudflare" {
 }
 
 provider "aws" {
-  region     = local.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
+  region = local.aws_region
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -124,17 +124,6 @@ variable "cloudflare_lexicon_zone_id" {
   type        = string
 }
 
-variable "aws_access_key" {
-  description = "Public access key for use with AWS."
-  type        = string
-}
-
-variable "aws_secret_key" {
-  description = "Secret key for use with AWS."
-  type        = string
-  sensitive   = true
-}
-
 variable "lexicon_database_password" {
   description = "The password for the Lexicon database."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -121,17 +121,6 @@ variable "cloudflare_lexicon_zone_id" {
   type        = string
 }
 
-variable "aws_access_key" {
-  description = "Public access key for use with AWS."
-  type        = string
-}
-
-variable "aws_secret_key" {
-  description = "Secret key for use with AWS."
-  type        = string
-  sensitive   = true
-}
-
 variable "lexicon_database_password" {
   description = "The password for the Lexicon database."
   type        = string


### PR DESCRIPTION
If OIDC worked we don't need this anymore. If this doesn't work the change can simply be reverted as the keys have not been removed yet.

# Tooling Change

This is a change to the tooling of `infrastructure`. It changes the internal workings of the repository and should have no noticeable effect on the plan.

Please see the commits tab of this pull request for the description of changes.
