### PR TITLE
Add a specific secrets manager role policy to the plan role

### DIFF
--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -33,6 +33,23 @@ module "terraform_plan_role" {
   run_phase = "plan"
 }
 
+data "aws_iam_policy_document" "plan_secret_access" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [module.lexicon.secret_manager_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "plan_secret_access" {
+  role   = module.terraform_plan_role.role_name
+  policy = data.aws_iam_policy_document.plan_secret_access.json
+}
+
 resource "aws_iam_role_policy_attachment" "readonly" {
   role       = module.terraform_plan_role.role_name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"

--- a/services/lexicon/outputs.tf
+++ b/services/lexicon/outputs.tf
@@ -1,0 +1,3 @@
+output "secret_manager_arn" {
+  value = module.lexicon_secrets.arn
+}


### PR DESCRIPTION
So it can read the secrets.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
