### PR TITLE
Add the AWS ECS repository URL to the actions variables

### DIFF
--- a/services/lexicon/github.tf
+++ b/services/lexicon/github.tf
@@ -17,6 +17,7 @@ module "lexicon_repository" {
     AWS_SECURITY_GROUP_ID     = module.lexicon_ecs_service.security_group_id
     AWS_SUBNET_IDS            = join(",", module.lexicon_ecs_service.subnet_ids)
     AWS_ASSIGN_PUBLIC_IP      = module.lexicon_ecs_service.assign_public_ip ? "ENABLED" : "DISABLED"
+    AWS_ECR_REPOSITORY_URL    = module.lexicon_ecr_image.repository_url
     DOCKER_USERNAME           = var.docker_username
     FRONT_END_SENTRY_DSN      = module.lexicon_sentry_front_end.public_dsn
   }


### PR DESCRIPTION
It will be needed to allow Lexicon to deploy to ECR.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
