### PR TITLE
Add create_before_destroy to load balancer target group

### DIFF
--- a/modules/aws/alb/resources.tf
+++ b/modules/aws/alb/resources.tf
@@ -45,6 +45,10 @@ resource "aws_lb_target_group" "default" {
     protocol = "HTTP"
     matcher  = "200"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb" "default" {


### PR DESCRIPTION
Otherwise apply fails due to dependency ordering whenever we destroy it.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
