### PR TITLE
Revert "Use our own VPC for Lexicon rather than the default one"

### DIFF
--- a/modules/aws/alb/data.tf
+++ b/modules/aws/alb/data.tf
@@ -1,0 +1,10 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}

--- a/modules/aws/alb/resources.tf
+++ b/modules/aws/alb/resources.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "alb" {
   name   = "${var.name}-alb"
-  vpc_id = var.vpc_id
+  vpc_id = data.aws_vpc.default.id
 
   lifecycle {
     create_before_destroy = true
@@ -35,7 +35,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
 resource "aws_lb_target_group" "default" {
   name        = "${var.name}-target-group"
   target_type = "ip"
-  vpc_id      = var.vpc_id
+  vpc_id      = data.aws_vpc.default.id
 
   port     = var.port
   protocol = "HTTP"
@@ -55,7 +55,7 @@ resource "aws_lb" "default" {
   name               = var.name
   security_groups    = [aws_security_group.alb.id]
   load_balancer_type = "application"
-  subnets            = var.subnet_ids
+  subnets            = data.aws_subnets.default.ids
 }
 
 resource "aws_lb_listener" "http" {

--- a/modules/aws/alb/variables.tf
+++ b/modules/aws/alb/variables.tf
@@ -18,13 +18,3 @@ variable "certificate_arn" {
   description = "ARN of the default SSL server certificate."
   type        = string
 }
-
-variable "vpc_id" {
-  description = "The VPC ID."
-  type        = string
-}
-
-variable "subnet_ids" {
-  description = "The subnet IDs."
-  type        = list(string)
-}

--- a/modules/aws/bastion/data.tf
+++ b/modules/aws/bastion/data.tf
@@ -1,3 +1,7 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
 data "aws_ami" "amazon_linux" {
   most_recent = true
 
@@ -6,5 +10,12 @@ data "aws_ami" "amazon_linux" {
   filter {
     name   = "name"
     values = ["al2023-ami-*-kernel-*-arm64"]
+  }
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
   }
 }

--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "bastion" {
   name   = var.name
-  vpc_id = var.vpc_id
+  vpc_id = data.aws_vpc.default.id
 
   lifecycle {
     create_before_destroy = true
@@ -35,7 +35,7 @@ resource "aws_key_pair" "bastion" {
 resource "aws_instance" "bastion" {
   ami                    = data.aws_ami.amazon_linux.id
   instance_type          = "t4g.nano"
-  subnet_id              = var.subnet_id
+  subnet_id              = data.aws_subnets.default.ids[0]
   vpc_security_group_ids = [aws_security_group.bastion.id]
 
   key_name = aws_key_pair.bastion.key_name

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -12,13 +12,3 @@ variable "public_ssh_key" {
   description = "The public key to use to log into the Bastion"
   type        = string
 }
-
-variable "vpc_id" {
-  description = "The VPC ID."
-  type        = string
-}
-
-variable "subnet_id" {
-  description = "The subnet ID."
-  type        = string
-}

--- a/modules/aws/database/data.tf
+++ b/modules/aws/database/data.tf
@@ -1,0 +1,3 @@
+data "aws_vpc" "default" {
+  default = true
+}

--- a/modules/aws/database/resources.tf
+++ b/modules/aws/database/resources.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "database" {
   name   = "${var.db_identifier}-database"
-  vpc_id = var.vpc_id
+  vpc_id = data.aws_vpc.default.id
 
   lifecycle {
     create_before_destroy = true

--- a/modules/aws/database/variables.tf
+++ b/modules/aws/database/variables.tf
@@ -29,8 +29,3 @@ variable "bastion_security_group_id" {
   description = "The security group ID for the associated Bastion."
   type        = string
 }
-
-variable "vpc_id" {
-  description = "The VPC ID."
-  type        = string
-}

--- a/modules/aws/ecs/data.tf
+++ b/modules/aws/ecs/data.tf
@@ -1,0 +1,10 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}

--- a/modules/aws/ecs/locals.tf
+++ b/modules/aws/ecs/locals.tf
@@ -1,7 +1,7 @@
 locals {
   network_configuration = {
     security_groups  = toset([aws_security_group.ecs.id])
-    subnets          = var.subnet_ids
+    subnets          = data.aws_subnets.default.ids
     assign_public_ip = true
   }
 }

--- a/modules/aws/ecs/resources.tf
+++ b/modules/aws/ecs/resources.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
 
 resource "aws_security_group" "ecs" {
   name   = "${var.name}-ecs"
-  vpc_id = var.vpc_id
+  vpc_id = data.aws_vpc.default.id
 
   lifecycle {
     create_before_destroy = true

--- a/modules/aws/ecs/variables.tf
+++ b/modules/aws/ecs/variables.tf
@@ -52,17 +52,6 @@ variable "lb_listener_arn" {
   type        = string
 }
 
-variable "vpc_id" {
-  description = "The VPC ID."
-  type        = string
-}
-
-variable "subnet_ids" {
-  description = "The subnet IDs."
-  type        = list(string)
-}
-
-
 variable "task_definitions" {
   description = "A list of tasks to associate with the service. It **must** contain exactly one task definition named 'service'."
   type = list(object({

--- a/services/lexicon/database.tf
+++ b/services/lexicon/database.tf
@@ -1,7 +1,5 @@
 module "lexicon_database" {
-  source = "../../modules/aws/database"
-
-  vpc_id                    = module.lexicon_network.vpc_id
+  source                    = "../../modules/aws/database"
   initial_db_name           = "lexicon"
   db_identifier             = "lexicon-prod"
   postgres_version          = "18"

--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -5,12 +5,9 @@ module "lexicon_ecr_image" {
 
 module "lexicon_ecs_service" {
   source = "../../modules/aws/ecs"
-
-  vpc_id     = module.lexicon_network.vpc_id
-  subnet_ids = module.lexicon_network.public_subnet_ids
-  name       = "lexicon"
-  image      = module.lexicon_ecr_image.repository_url
-  port       = local.backend_port
+  name   = "lexicon"
+  image  = module.lexicon_ecr_image.repository_url
+  port   = local.backend_port
   environment_variables = {
     NODE_ENV         = "production"
     API_BASE_URL     = "https://${var.lexicon_domain}"

--- a/services/lexicon/networking.tf
+++ b/services/lexicon/networking.tf
@@ -2,22 +2,13 @@ locals {
   backend_port = 8080
 }
 
-module "lexicon_network" {
-  source = "../../modules/aws/network"
-  name   = "lexicon"
-}
-
 module "lexicon_bastion" {
   source = "../../modules/aws/bastion"
-
-  name           = "lexicon-bastion"
-  public_ssh_key = var.public_ssh_key
-  vpc_id         = module.lexicon_network.vpc_id
-  subnet_id      = module.lexicon_network.public_subnet_ids[0]
-
+  name   = "lexicon-bastion"
   allowed_ipv4s = {
     alex_home = "81.103.172.13/32"
   }
+  public_ssh_key = var.public_ssh_key
 }
 
 module "lexicon_acm_certificate" {
@@ -54,10 +45,7 @@ module "lexicon_acm_certificate_validation" {
 }
 
 module "lexicon_load_balancer" {
-  source = "../../modules/aws/alb"
-
-  vpc_id            = module.lexicon_network.vpc_id
-  subnet_ids        = module.lexicon_network.public_subnet_ids
+  source            = "../../modules/aws/alb"
   name              = "lexicon"
   health_check_path = "/api/v1"
   port              = local.backend_port


### PR DESCRIPTION
This reverts commit 9389e2da94828fbd736eb0a3638d0f9948ac56a8.

Yeah, probably a bit too ambitious to try and migrate the VPC all in one go...

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
