### PR TITLE
Use a different instance type

### DIFF
--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -34,7 +34,7 @@ resource "aws_key_pair" "bastion" {
 
 resource "aws_instance" "bastion" {
   ami                    = data.aws_ami.amazon_linux.id
-  instance_type          = "t4g.nano"
+  instance_type          = "t4g.micro"
   subnet_id              = data.aws_subnets.default.ids[0]
   vpc_security_group_ids = [aws_security_group.bastion.id]
 


### PR DESCRIPTION
Apparently they themselves are out of t4g.nano, so attempting a fix by choosing a different instance type.