### PR TITLE
Have the secrets manager output the secrets in the format ECS expects…

### DIFF
--- a/modules/aws/secrets_manager/outputs.tf
+++ b/modules/aws/secrets_manager/outputs.tf
@@ -2,3 +2,11 @@ output "arn" {
   description = "ARN of the secret."
   value       = aws_secretsmanager_secret.default.arn
 }
+
+output "secret_arns" {
+  description = "Mapping of secret names to the Secrets Manager ARN containing them."
+  value = {
+    for name in nonsensitive(keys(var.secrets)) :
+    name => aws_secretsmanager_secret.default.arn
+  }
+}

--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -18,10 +18,7 @@ module "lexicon_ecs_service" {
     GOOGLE_CLIENT_ID = var.lexicon_google_client_id
     SENTRY_DSN       = module.lexicon_sentry_back_end.public_dsn
   }
-  secret_arns = {
-    DATABASE_URL         = module.lexicon_secrets.arn
-    GOOGLE_CLIENT_SECRET = module.lexicon_secrets.arn
-  }
+  secret_arns     = module.lexicon_secrets.secret_arns
   fargate_version = "1.4.0"
 
   task_definitions = [{


### PR DESCRIPTION
… natively, then pass that to the ECS module

This gets rid of the need to maintain the two separate representations of the secrets, therefore allowing the secret manager to be the real source of truth.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
