### PR TITLE
Initial setup of new Lexicon deployment (again!)

### DIFF
--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -17,3 +17,23 @@ module "lexicon" {
   cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
   sentry_organisation_id            = module.sentry_organisation.id
 }
+
+module "lexicon_london" {
+  source                    = "./lexicon_london"
+  lexicon_database_password = var.lexicon_database_password
+  required_ci_checks = concat(local.check_list.base, [
+    local.check_name.lexicon.lint_ci,
+    local.check_name.lexicon.test_ci,
+    local.check_name.lexicon.end_to_end_ci
+  ])
+  github_labels                     = merge(local.labels.standard, local.labels.app)
+  alex_up_bot_app_id                = var.alex_up_bot_app_id
+  deployment_role_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
+  lexicon_domain                    = var.lexicon_domain
+  lexicon_google_client_id          = var.lexicon_google_client_id
+  lexicon_google_client_secret      = var.lexicon_google_client_secret
+  public_ssh_key                    = var.public_ssh_key
+  aws_region                        = local.aws_region
+  cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
+  sentry_organisation_id            = module.sentry_organisation.id
+}

--- a/services/lexicon_london/load_balancer.tf
+++ b/services/lexicon_london/load_balancer.tf
@@ -1,0 +1,42 @@
+module "lexicon_acm_certificate" {
+  source                    = "../../modules/aws/acm_certificate"
+  domain_name               = var.lexicon_domain
+  subject_alternative_names = ["www.${var.lexicon_domain}"]
+}
+
+module "lexicon_dns_validation_records" {
+  for_each = {
+    for option in module.lexicon_acm_certificate.domain_validation_options :
+    option.domain_name => option
+  }
+
+  source = "../../modules/cloudflare/dns"
+
+  name    = each.value.resource_record_name
+  type    = each.value.resource_record_type
+  content = each.value.resource_record_value
+
+  zone_id = var.cloudflare_lexicon_zone_id
+  proxied = false
+  ttl     = 660
+}
+
+module "lexicon_acm_certificate_validation" {
+  source = "../../modules/aws/certificate_validation"
+
+  certificate_arn = module.lexicon_acm_certificate.certificate_arn
+  validation_record_fqdns = [
+    for record in module.lexicon_dns_validation_records :
+    record.fqdn
+  ]
+}
+
+module "lexicon_load_balancer" {
+  source            = "../../modules/aws/alb"
+  name              = "lexicon"
+  health_check_path = "/api/v1"
+  port              = local.backend_port
+  certificate_arn   = module.lexicon_acm_certificate_validation.validated_certificate_arn
+  vpc_id            = module.lexicon_network.vpc_id
+  subnet_ids        = module.lexicon_network.public_subnet_ids
+}

--- a/services/lexicon_london/locals.tf
+++ b/services/lexicon_london/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  backend_port = 8080
+}

--- a/services/lexicon_london/main.tf
+++ b/services/lexicon_london/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
+    sentry = {
+      source  = "jianyuan/sentry"
+      version = ">=0.14.3"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">=5.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}

--- a/services/lexicon_london/variables.tf
+++ b/services/lexicon_london/variables.tf
@@ -1,0 +1,65 @@
+variable "lexicon_database_password" {
+  description = "The password for the Lexicon database."
+  type        = string
+  sensitive   = true
+}
+
+variable "required_ci_checks" {
+  description = "The checks required on the Lexicon repository for CI to pass."
+  type        = list(string)
+}
+
+variable "github_labels" {
+  description = "The labels for the GitHub repository"
+  type = map(object({
+    color       = string
+    description = string
+  }))
+  default = {}
+}
+
+variable "alex_up_bot_app_id" {
+  description = "App ID for alex-up-bot."
+  type        = string
+}
+
+variable "deployment_role_oidc_provider_arn" {
+  description = "The OIDC provider ARN for the deployment role."
+  type        = string
+}
+
+variable "lexicon_domain" {
+  description = "The domain name for Lexicon"
+  type        = string
+}
+
+variable "lexicon_google_client_id" {
+  description = "The Google Client ID for the Lexicon project."
+  type        = string
+}
+
+variable "lexicon_google_client_secret" {
+  description = "The Google Client Secret for the Lexicon project."
+  type        = string
+  sensitive   = true
+}
+
+variable "public_ssh_key" {
+  description = "My public SSH key"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "The AWS region to use"
+  type        = string
+}
+
+variable "cloudflare_lexicon_zone_id" {
+  description = "The Cloudflare Lexicon Zone ID"
+  type        = string
+}
+
+variable "sentry_organisation_id" {
+  description = "The Sentry organisation ID."
+  type        = string
+}

--- a/services/lexicon_london/vpc.tf
+++ b/services/lexicon_london/vpc.tf
@@ -1,0 +1,4 @@
+module "lexicon_network" {
+  source = "../../modules/aws/network"
+  name   = "lexicon"
+}


### PR DESCRIPTION
We are migrating away from eu-north-1 to eu-west-2, and also using our own VPC and subnets rather than the default ones.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
