### PR TITLE
Move the validation records to the new Lexicon deployment

### DIFF
--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -37,3 +37,8 @@ module "lexicon_london" {
   cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
   sentry_organisation_id            = module.sentry_organisation.id
 }
+
+moved {
+  from = module.lexicon.module.lexicon_dns_validation_records
+  to   = module.lexicon_london.module.lexicon_dns_validation_records
+}

--- a/services/lexicon/networking.tf
+++ b/services/lexicon/networking.tf
@@ -19,39 +19,12 @@ module "lexicon_acm_certificate" {
   subject_alternative_names = ["www.${var.lexicon_domain}"]
 }
 
-module "lexicon_dns_validation_records" {
-  for_each = {
-    for option in module.lexicon_acm_certificate.domain_validation_options :
-    option.domain_name => option
-  }
-
-  source = "../../modules/cloudflare/dns"
-
-  name    = each.value.resource_record_name
-  type    = each.value.resource_record_type
-  content = each.value.resource_record_value
-
-  zone_id = var.cloudflare_lexicon_zone_id
-  proxied = false
-  ttl     = 660
-}
-
-module "lexicon_acm_certificate_validation" {
-  source = "../../modules/aws/certificate_validation"
-
-  certificate_arn = module.lexicon_acm_certificate.certificate_arn
-  validation_record_fqdns = [
-    for record in module.lexicon_dns_validation_records :
-    record.fqdn
-  ]
-}
-
 module "lexicon_load_balancer" {
   source            = "../../modules/aws/alb"
   name              = "lexicon"
   health_check_path = "/api/v1"
   port              = local.backend_port
-  certificate_arn   = module.lexicon_acm_certificate_validation.validated_certificate_arn
+  certificate_arn   = module.lexicon_acm_certificate.certificate_arn
   vpc_id            = data.aws_vpc.default.id
   subnet_ids        = data.aws_subnets.default.ids
 }


### PR DESCRIPTION
They are actually identical between them both, so this can be moved over as is without needing to recreate the records.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
