### PR TITLE
Use a private subnet group for the database rather than a public one

### DIFF
--- a/modules/aws/network/locals.tf
+++ b/modules/aws/network/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  subnet_count = min(4, length(data.aws_availability_zones.available.names))
+}

--- a/modules/aws/network/outputs.tf
+++ b/modules/aws/network/outputs.tf
@@ -14,6 +14,6 @@ output "public_route_table_id" {
   value = aws_route_table.public.id
 }
 
-output "public_subnet_group_name" {
-  value = aws_db_subnet_group.public.name
+output "db_subnet_group_name" {
+  value = aws_db_subnet_group.default.name
 }

--- a/modules/aws/network/resources.tf
+++ b/modules/aws/network/resources.tf
@@ -9,7 +9,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_subnet" "public" {
-  count = min(4, length(data.aws_availability_zones.available.names))
+  count = local.subnet_count
 
   vpc_id                  = aws_vpc.default.id
   availability_zone       = data.aws_availability_zones.available.names[count.index]
@@ -17,6 +17,18 @@ resource "aws_subnet" "public" {
   cidr_block              = cidrsubnet(var.cidr_block, 10, count.index)
   tags = {
     Name = "${var.name}-public-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count = local.subnet_count
+
+  vpc_id                  = aws_vpc.default.id
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = false
+  cidr_block              = cidrsubnet(var.cidr_block, 10, count.index + local.subnet_count)
+  tags = {
+    Name = "${var.name}-private-${count.index + 1}"
   }
 }
 
@@ -46,10 +58,10 @@ resource "aws_route_table_association" "public_gateway" {
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_db_subnet_group" "public" {
-  name = var.name
+resource "aws_db_subnet_group" "default" {
+  name = "${var.name}-subnet-group"
 
-  subnet_ids = aws_subnet.public[*].id
+  subnet_ids = aws_subnet.private[*].id
 
   tags = {
     Name = var.name

--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -7,5 +7,5 @@ module "lexicon_database" {
   password                  = var.lexicon_database_password
   bastion_security_group_id = module.lexicon_bastion.security_group_id
   vpc_id                    = module.lexicon_network.vpc_id
-  db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
+  db_subnet_group_name      = module.lexicon_network.db_subnet_group_name
 }


### PR DESCRIPTION
I think this is the more conventional approach, and also feels better so that we limit exactly what services are allowed to communicate with the database.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.


