### PR TITLE
Temporarily add back the public subnet group during the migration

### DIFF
--- a/modules/aws/network/resources.tf
+++ b/modules/aws/network/resources.tf
@@ -67,3 +67,13 @@ resource "aws_db_subnet_group" "default" {
     Name = var.name
   }
 }
+
+resource "aws_db_subnet_group" "public" {
+  name = var.name
+
+  subnet_ids = aws_subnet.public[*].id
+
+  tags = {
+    Name = var.name
+  }
+}


### PR DESCRIPTION
Otherwise it struggles to destroy the old group because the database is still using the public group.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
