### PR TITLE
Destroy the London Lexicon database

### DIFF
--- a/modules/aws/network/resources.tf
+++ b/modules/aws/network/resources.tf
@@ -67,13 +67,3 @@ resource "aws_db_subnet_group" "default" {
     Name = var.name
   }
 }
-
-resource "aws_db_subnet_group" "public" {
-  name = var.name
-
-  subnet_ids = aws_subnet.public[*].id
-
-  tags = {
-    Name = var.name
-  }
-}

--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -1,11 +1,11 @@
-module "lexicon_database" {
-  source                    = "../../modules/aws/database"
-  initial_db_name           = "lexicon"
-  db_identifier             = "lexicon-prod"
-  postgres_version          = "18"
-  username                  = "lexicon_user"
-  password                  = var.lexicon_database_password
-  bastion_security_group_id = module.lexicon_bastion.security_group_id
-  vpc_id                    = module.lexicon_network.vpc_id
-  db_subnet_group_name      = module.lexicon_network.db_subnet_group_name
-}
+# module "lexicon_database" {
+#   source                    = "../../modules/aws/database"
+#   initial_db_name           = "lexicon"
+#   db_identifier             = "lexicon-prod"
+#   postgres_version          = "18"
+#   username                  = "lexicon_user"
+#   password                  = var.lexicon_database_password
+#   bastion_security_group_id = module.lexicon_bastion.security_group_id
+#   vpc_id                    = module.lexicon_network.vpc_id
+#   db_subnet_group_name      = module.lexicon_network.db_subnet_group_name
+# }


### PR DESCRIPTION
So I can recreate it using the correct subnet group. Note that this is fine because there is no production data in it yet. In fact, there is no data at all in it yet.

# Irreversible Destruction

This is a change to `infrastructure` that irreversibly destroys a managed Terraform resource. This change can **NOT** be fixed by simply reverting back the changes as it will try recreating the resource entirely and there is no guarantee that it will be restored back to the same state it was previously in.

Please take extra care before merging this one in, and be absolutely sure that you intend to fully remove the resource associated with this pull request.

Please see the commits tab of this pull request for the description of changes.
