### PR TITLE
Use the public subnet group name for now

### DIFF
--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -7,5 +7,5 @@ module "lexicon_database" {
   password                  = var.lexicon_database_password
   bastion_security_group_id = module.lexicon_bastion.security_group_id
   vpc_id                    = module.lexicon_network.vpc_id
-  db_subnet_group_name      = module.lexicon_network.db_subnet_group_name
+  db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
 }


### PR DESCRIPTION
# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
