### PR TITLE
Disable deletion protection

### DIFF
--- a/modules/aws/database/resources.tf
+++ b/modules/aws/database/resources.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "default" {
 
   backup_retention_period = 7
 
-  deletion_protection = true
+  deletion_protection = var.deletion_protection
 
   publicly_accessible = false
 

--- a/modules/aws/database/variables.tf
+++ b/modules/aws/database/variables.tf
@@ -40,3 +40,9 @@ variable "db_subnet_group_name" {
   type        = string
   default     = null
 }
+
+variable "deletion_protection" {
+  description = "Whether to protect the database from being destroyed or not."
+  type        = bool
+  default     = true
+}

--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -1,11 +1,12 @@
-# module "lexicon_database" {
-#   source                    = "../../modules/aws/database"
-#   initial_db_name           = "lexicon"
-#   db_identifier             = "lexicon-prod"
-#   postgres_version          = "18"
-#   username                  = "lexicon_user"
-#   password                  = var.lexicon_database_password
-#   bastion_security_group_id = module.lexicon_bastion.security_group_id
-#   vpc_id                    = module.lexicon_network.vpc_id
-#   db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
-# }
+module "lexicon_database" {
+  source                    = "../../modules/aws/database"
+  initial_db_name           = "lexicon"
+  db_identifier             = "lexicon-prod"
+  postgres_version          = "18"
+  username                  = "lexicon_user"
+  password                  = var.lexicon_database_password
+  bastion_security_group_id = module.lexicon_bastion.security_group_id
+  vpc_id                    = module.lexicon_network.vpc_id
+  db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
+  deletion_protection       = false
+}


### PR DESCRIPTION
So we can destroy the database so we can migrate the subnets over. I have made this a variable that defaults to true so all databases get this by default unless explicitly opted out of.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
