### PR TITLE
Finally destroy the London Lexicon database for real this time I swea…

### DIFF
--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -1,12 +1,12 @@
-module "lexicon_database" {
-  source                    = "../../modules/aws/database"
-  initial_db_name           = "lexicon"
-  db_identifier             = "lexicon-prod"
-  postgres_version          = "18"
-  username                  = "lexicon_user"
-  password                  = var.lexicon_database_password
-  bastion_security_group_id = module.lexicon_bastion.security_group_id
-  vpc_id                    = module.lexicon_network.vpc_id
-  db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
-  deletion_protection       = false
-}
+# module "lexicon_database" {
+#   source                    = "../../modules/aws/database"
+#   initial_db_name           = "lexicon"
+#   db_identifier             = "lexicon-prod"
+#   postgres_version          = "18"
+#   username                  = "lexicon_user"
+#   password                  = var.lexicon_database_password
+#   bastion_security_group_id = module.lexicon_bastion.security_group_id
+#   vpc_id                    = module.lexicon_network.vpc_id
+#   db_subnet_group_name      = module.lexicon_network.public_subnet_group_name
+#   deletion_protection       = false
+# }


### PR DESCRIPTION
…r it will work

# Irreversible Destruction

This is a change to `infrastructure` that irreversibly destroys a managed Terraform resource. This change can **NOT** be fixed by simply reverting back the changes as it will try recreating the resource entirely and there is no guarantee that it will be restored back to the same state it was previously in.

Please take extra care before merging this one in, and be absolutely sure that you intend to fully remove the resource associated with this pull request.

Please see the commits tab of this pull request for the description of changes.
