### PR TITLE
Enable deletion protection on London Lexicon database

### DIFF
--- a/services/lexicon_london/database.tf
+++ b/services/lexicon_london/database.tf
@@ -8,5 +8,4 @@ module "lexicon_database" {
   bastion_security_group_id = module.lexicon_bastion.security_group_id
   vpc_id                    = module.lexicon_network.vpc_id
   db_subnet_group_name      = module.lexicon_network.db_subnet_group_name
-  deletion_protection       = false
 }


### PR DESCRIPTION
This will make it harder to accidentally destroy the database - we would need to explicitly disable deletion protection if we want to do that.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
