### PR TITLE
Change the aws_region variable to be eu_west_2

### DIFF
--- a/docs/changeRequests/2026-07-04_manually_grant_secrets_access_in_aws.md
+++ b/docs/changeRequests/2026-07-04_manually_grant_secrets_access_in_aws.md
@@ -1,0 +1,11 @@
+# Change Request
+
+This is a request for a change to infrastructure by AlexMan123456. If this gets accepted it will trigger a new deployment to apply the change. Please see more details below.
+
+## Change reason
+
+Manually grant secrets access in AWS
+
+## Change description
+
+We need to give the role permissions to run the plan, but we need to run the plan to give the role permissions. As such, I have manually added permissions for now, and the next apply should then correct it to be less broad than what is currently set manually

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "plan_secret_access" {
       "secretsmanager:GetSecretValue"
     ]
 
-    resources = [module.lexicon.secret_manager_arn]
+    resources = [module.lexicon.secret_manager_arn, module.lexicon_london.secret_manager_arn]
   }
 }
 

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -33,7 +33,7 @@ module "lexicon_london" {
   lexicon_google_client_id          = var.lexicon_google_client_id
   lexicon_google_client_secret      = var.lexicon_google_client_secret
   public_ssh_key                    = var.public_ssh_key
-  aws_region                        = local.aws_region
+  aws_region                        = "eu-west-2"
   cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
   sentry_organisation_id            = module.sentry_organisation.id
 }

--- a/services/lexicon_london/main.tf
+++ b/services/lexicon_london/main.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  region = var.aws_region
 }

--- a/services/lexicon_london/outputs.tf
+++ b/services/lexicon_london/outputs.tf
@@ -1,0 +1,3 @@
+output "secret_manager_arn" {
+  value = module.lexicon_secrets.arn
+}


### PR DESCRIPTION
It is already configured this way in the service itself, but this ensures the variable aligns so GitHub also gets the correct region.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
