### PR TITLE
Remove all moved blocks

### DIFF
--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -37,23 +37,3 @@ module "lexicon_london" {
   cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
   sentry_organisation_id            = module.sentry_organisation.id
 }
-
-moved {
-  from = module.lexicon.module.lexicon_sentry_back_end
-  to   = module.lexicon_london.module.lexicon_sentry_back_end
-}
-
-moved {
-  from = module.lexicon.module.lexicon_sentry_front_end
-  to   = module.lexicon_london.module.lexicon_sentry_front_end
-}
-
-moved {
-  from = module.lexicon.module.lexicon_repository
-  to   = module.lexicon_london.module.lexicon_repository
-}
-
-moved {
-  from = module.lexicon.module.lexicon_deployment_role
-  to   = module.lexicon_london.module.lexicon_deployment_role
-}

--- a/services/lexicon/main.tf
+++ b/services/lexicon/main.tf
@@ -18,8 +18,3 @@ terraform {
     }
   }
 }
-
-moved {
-  from = module.lexicon_ecs_service.aws_iam_role.ecs_task_execution
-  to   = module.lexicon_ecs_task_execution_role.aws_iam_role.ecs_task_execution
-}


### PR DESCRIPTION
The migration is done so the moved blocks no longer need to be here.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
