### PR TITLE
Canonicise the London Lexicon deployment as the official deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,10 @@ jobs:
               printing=1
           }
 
+          /^Terraform will perform the following actions:/ {
+              printing=1
+          }
+
           /^No changes\. Your infrastructure matches the configuration\./ {
               printing=1
           }

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "plan_secret_access" {
       "secretsmanager:GetSecretValue"
     ]
 
-    resources = [module.lexicon_london.secret_manager_arn]
+    resources = [module.lexicon.secret_manager_arn]
   }
 }
 

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -1,4 +1,4 @@
-module "lexicon_london" {
+module "lexicon" {
   source                    = "./lexicon"
   lexicon_database_password = var.lexicon_database_password
   required_ci_checks = concat(local.check_list.base, [
@@ -16,4 +16,9 @@ module "lexicon_london" {
   aws_region                        = "eu-west-2"
   cloudflare_lexicon_zone_id        = var.cloudflare_lexicon_zone_id
   sentry_organisation_id            = module.sentry_organisation.id
+}
+
+moved {
+  from = module.lexicon_london
+  to   = module.lexicon
 }


### PR DESCRIPTION
The third time really was the charm after all!

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
