### PR TITLE
Change the region in the locals

### DIFF
--- a/services/aws.tf
+++ b/services/aws.tf
@@ -1,3 +1,3 @@
 locals {
-  aws_region = "eu-north-1"
+  aws_region = "eu-west-2"
 }


### PR DESCRIPTION
It makes it easier to say that future deployments should use eu-west-2. I think it's currently hardcoded as of now in the Lexicon service, but I will remove the hardcoding in a different commit.