### PR TITLE
Make scheduled applies more frequent

### DIFF
--- a/.github/workflows/scheduled-apply.yml
+++ b/.github/workflows/scheduled-apply.yml
@@ -2,7 +2,7 @@ name: Scheduled Apply
 
 on:
   schedule:
-    - cron: 0 21 1 * *
+    - cron: 0 9 * * 1
 
 jobs:
   scheduled-apply:


### PR DESCRIPTION
I think it's more beneficial for Infrastructure to have consistent scheduled applies rather than Lexicon itself. Reason being, we can also see what Terraform plans to change and so we can use that to make an informed decision on whether we want to normalise Infrastructure state or not. As opposed to in Lexicon where we can't really be sure the deployment will actually change anything. Hence I'll make Infrastructure scheduled deployments more frequent and Lexicon scheduled deployments less frequent.