### PR TITLE
Require the legacy CI workflows in alex-c-line to pass

### DIFF
--- a/services/ci_jobs.tf
+++ b/services/ci_jobs.tf
@@ -10,6 +10,11 @@ locals {
 
     end_to_end_ci = "end-to-end-ci / end-to-end-ci"
 
+    alex_c_line = {
+      source_code_ci_legacy = "package-ci-legacy / source-code-ci"
+      end_to_end_ci_legacy  = "end-to-end-legacy / end-to-end-ci"
+    }
+
     terraform = {
       lint_ci      = "terraform-lint-ci"
       plan_ci      = "terraform-plan-ci"
@@ -58,6 +63,10 @@ locals {
       local.check_name.actions_ci,
       local.check_name.end_to_end_ci
     ])
+
+    alex_c_line = {
+      legacy = [local.check_name.alex_c_line.source_code_ci_legacy, local.check_name.alex_c_line.end_to_end_ci_legacy]
+    }
 
     github_actions = {
       base = [

--- a/services/packages.tf
+++ b/services/packages.tf
@@ -39,7 +39,7 @@ module "alex_c_line_repository" {
   name               = "alex-c-line"
   description        = "Command-line tool with commands to streamline the developer workflow."
   visibility         = "public"
-  required_ci_checks = local.check_list.package
+  required_ci_checks = concat(local.check_list.package, local.check_list.alex_c_line.legacy)
   alex_up_bot_app_id = var.alex_up_bot_app_id
   labels             = merge(local.labels.standard, local.labels.package)
 }


### PR DESCRIPTION
It should ideally still be Node 22 compatible for now while Node 26 is new. As such, the new legacy workflows that run Node 22 should be required until Node 26 reaches long-term support.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
