### PR TITLE
Add an Elastic IP to the Bastion

### DIFF
--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -1,3 +1,7 @@
+resource "aws_eip" "bastion" {
+  domain = "vpc"
+}
+
 resource "aws_security_group" "bastion" {
   name   = var.name
   vpc_id = var.vpc_id
@@ -43,4 +47,9 @@ resource "aws_instance" "bastion" {
   tags = {
     Name = var.name
   }
+}
+
+resource "aws_eip_association" "bastion" {
+  allocation_id = aws_eip.bastion.id
+  instance_id   = aws_instance.bastion.id
 }


### PR DESCRIPTION
That way, whenever the AMI updates, instead of having to also get the new IP every time, it would instead just point to the Elastic IP and all we would have to do in the Bastion is just set up Postgres again.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
