### PR TITLE
Add the name as a tag for the Bastion Elastic IP

### DIFF
--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -1,4 +1,7 @@
 resource "aws_eip" "bastion" {
+  tags = {
+    Name = "${var.name}-elastic-ip"
+  }
   domain = "vpc"
 }
 


### PR DESCRIPTION
Should make it easier to find in the AWS console.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
