### PR TITLE
Use the internal Sentry project ID

### DIFF
--- a/modules/sentry/project/resources.tf
+++ b/modules/sentry/project/resources.tf
@@ -9,7 +9,7 @@ resource "sentry_organization_code_mapping" "default" {
   organization   = var.organisation_id
   integration_id = var.github_integration_id
   repository_id  = var.sentry_repository_id
-  project_id     = sentry_project.default.id
+  project_id     = sentry_project.default.internal_id
 
   default_branch = "main"
   stack_root     = "/"


### PR DESCRIPTION
That's an integer so maybe it expects that.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
