### PR TITLE
Add user_data to the Bastion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "**/templates/**/*.sh.tftpl": "shellscript"
+    }
+}

--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -17,6 +17,14 @@ resource "aws_instance" "bastion" {
   vpc_security_group_ids = var.security_group_ids
 
   key_name = aws_key_pair.bastion.key_name
+  user_data = templatefile("${path.module}/templates/bastion_user_data.sh.tftpl", {
+    postgres_version = var.postgres_version
+    database_address = var.database_address
+    port             = var.port
+    database_user    = var.database_user
+    database_name    = var.database_name
+  })
+  user_data_replace_on_change = true
 
   tags = {
     Name = var.name

--- a/modules/aws/bastion/templates/bastion_user_data.sh.tftpl
+++ b/modules/aws/bastion/templates/bastion_user_data.sh.tftpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf install -y postgresql${postgres_version}
+
+cat >/etc/profile.d/lexicon.sh <<EOF
+lexicon-db() {
+    psql \
+        -h "${database_address}" \
+        -p "${port}" \
+        -U "${database_user}" \
+        -d "${database_name}" \
+        "$@"
+}
+EOF

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -17,3 +17,29 @@ variable "security_group_ids" {
   description = "List of security group IDs to associate with the Bastion"
   type        = list(string)
 }
+
+variable "postgres_version" {
+  description = "The Postgres version"
+  type        = string
+  default     = "18"
+}
+
+variable "database_address" {
+  description = "The database host address."
+  type        = string
+}
+
+variable "port" {
+  description = "The database connection port."
+  type        = string
+}
+
+variable "database_user" {
+  description = "The username of the user to connect to the database with."
+  type        = string
+}
+
+variable "database_name" {
+  description = "The name of the database."
+  type        = string
+}

--- a/modules/aws/database/outputs.tf
+++ b/modules/aws/database/outputs.tf
@@ -6,3 +6,24 @@ output "database_url" {
   sensitive = true
   value     = "postgresql://${var.username}:${var.password}@${aws_db_instance.default.address}:5432/${var.initial_db_name}"
 }
+
+output "postgres_version" {
+  value = aws_db_instance.default.engine_version
+}
+
+output "address" {
+  value = aws_db_instance.default.address
+}
+
+output "port" {
+  value = aws_db_instance.default.port
+}
+
+output "db_name" {
+  value = aws_db_instance.default.db_name
+}
+
+output "username" {
+  value = aws_db_instance.default.username
+}
+

--- a/services/lexicon/bastion.tf
+++ b/services/lexicon/bastion.tf
@@ -4,6 +4,10 @@ module "lexicon_bastion" {
   public_ssh_key     = var.public_ssh_key
   subnet_id          = module.lexicon_network.public_subnet_ids[0]
   security_group_ids = [module.lexicon_bastion_security_group.id]
+  database_address   = module.lexicon_database.address
+  database_name      = module.lexicon_database.db_name
+  database_user      = module.lexicon_database.username
+  port               = module.lexicon_database.port
 }
 
 module "lexicon_bastion_allowed_ips" {


### PR DESCRIPTION
This should give us a nice base setup that will always exist in the Bastion should it ever get recreated (e.g. due to an AMI update).

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
