### PR TITLE
Remove the aliasing in user_data

### DIFF
--- a/modules/aws/bastion/templates/bastion_user_data.sh.tftpl
+++ b/modules/aws/bastion/templates/bastion_user_data.sh.tftpl
@@ -4,7 +4,6 @@ set -euxo pipefail
 dnf install -y postgresql${postgres_version}
 
 cat >/etc/profile.d/lexicon.sh <<EOF
-alias bastion-test='echo Hello!'
 lexicon-db() {
     psql \
         -h "${database_address}" \


### PR DESCRIPTION
So we can test what happens if we don't recreate the Bastion on user_data change for real.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
