### PR TITLE
Replace the Bastion on user_data change

### DIFF
--- a/modules/aws/bastion/resources.tf
+++ b/modules/aws/bastion/resources.tf
@@ -24,6 +24,7 @@ resource "aws_instance" "bastion" {
     database_user    = var.database_user
     database_name    = var.database_name
   })
+  user_data_replace_on_change = true
 
   tags = {
     Name = var.name


### PR DESCRIPTION
This is needed, otherwise the user_data doesn't automatically run on new changes to the Bastion.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
