### PR TITLE
Apply sensitivity to the values in the module itself rather than mark…

### DIFF
--- a/modules/aws/secrets_manager/outputs.tf
+++ b/modules/aws/secrets_manager/outputs.tf
@@ -6,7 +6,7 @@ output "arn" {
 output "secret_arns" {
   description = "Mapping of secret names to the Secrets Manager ARN containing them."
   value = {
-    for name in nonsensitive(keys(var.secrets)) :
+    for name in keys(var.secrets) :
     name => aws_secretsmanager_secret.default.arn
   }
 }

--- a/modules/aws/secrets_manager/resources.tf
+++ b/modules/aws/secrets_manager/resources.tf
@@ -3,6 +3,9 @@ resource "aws_secretsmanager_secret" "default" {
 }
 
 resource "aws_secretsmanager_secret_version" "default" {
-  secret_id     = aws_secretsmanager_secret.default.id
-  secret_string = jsonencode(var.secrets)
+  secret_id = aws_secretsmanager_secret.default.id
+  secret_string = jsonencode({
+    for key, value in var.secrets :
+    key => sensitive(value)
+  })
 }

--- a/modules/aws/secrets_manager/variables.tf
+++ b/modules/aws/secrets_manager/variables.tf
@@ -6,5 +6,4 @@ variable "name" {
 variable "secrets" {
   description = "The secrets to use."
   type        = map(string)
-  sensitive   = true
 }


### PR DESCRIPTION
… the entire secrets object as sensitive

This allows us to use the keys nonsensitively as is without needing to explicitly use the nonsensitive function in the code. The values then get mapped sensitive in resources.tf itself.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
