### PR TITLE
Remove the status field

### DIFF
--- a/services/lexicon/dns.tf
+++ b/services/lexicon/dns.tf
@@ -19,5 +19,4 @@ module "lexicon_dns_record" {
 
 resource "cloudflare_zone_dnssec" "lexicon_domain" {
   zone_id = data.cloudflare_zone.lexicon_domain.zone_id
-  status  = "active"
 }


### PR DESCRIPTION
It might be causing plan noise having that there as this seems like it's trying to force the DNSSEC to be active when it's currently pending.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
