### PR TITLE
Add the TF_CLOUD_ORGANIZATION and TF_WORKSPACE variables as actions v…

### DIFF
--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -15,6 +15,10 @@ module "infrastructure_repository" {
     local.check_name.terraform.comment_plan
   ])
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  variables = {
+    TF_CLOUD_ORGANIZATION = module.tfe_organisation.organisation_name
+    TF_WORKSPACE          = module.infrastructure_workspace.workspace_name
+  }
   secrets = {
     TFE_TOKEN = var.tfe_token
   }


### PR DESCRIPTION
…ariables

So we don't have to hardcode these values in the workflow itself and can instead rely on the values from HCP Terraform as the source of truth.

# Miscellaneous

This is a general change to `infrastructure` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
