### PR TITLE
Use a data source to get the alex-up-bot app ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ module "services" {
   tfe_token                                  = var.tfe_token
   tfe_org_token                              = var.tfe_org_token
   lexicon_google_client_id                   = var.lexicon_google_client_id
-  alex_up_bot_app_id                         = var.alex_up_bot_app_id
   alex_up_bot_private_key                    = var.alex_up_bot_private_key
   alex_infrastructure_bot_app_id             = var.alex_infrastructure_bot_app_id
   alex_infrastructure_bot_installation_id    = var.alex_infrastructure_bot_installation_id

--- a/modules/github/repository/data.tf
+++ b/modules/github/repository/data.tf
@@ -1,0 +1,3 @@
+data "github_app" "alex_up_bot" {
+  slug = "alex-up-bot"
+}

--- a/modules/github/repository/rulesets.tf
+++ b/modules/github/repository/rulesets.tf
@@ -106,7 +106,7 @@ resource "github_repository_ruleset" "restrict_version_tags" {
 
   bypass_actors {
     actor_type  = "Integration"
-    actor_id    = var.alex_up_bot_app_id
+    actor_id    = data.github_app.alex_up_bot.id
     bypass_mode = "exempt"
   }
 

--- a/modules/github/repository/variables.tf
+++ b/modules/github/repository/variables.tf
@@ -42,11 +42,6 @@ variable "required_ci_checks" {
   default     = []
 }
 
-variable "alex_up_bot_app_id" {
-  description = "App ID for alex-up-bot, commonly used to create pull requests in GitHub Actions."
-  type        = string
-}
-
 variable "has_pages" {
   description = "Enable GitHub Pages deployment for the repository."
   type        = bool

--- a/services/archived_repositories.tf
+++ b/services/archived_repositories.tf
@@ -5,7 +5,6 @@ module "neurosongs_2_repository" {
   visibility         = "public"
   archived           = true
   required_ci_checks = concat(local.check_list.base, [local.check_name.neurosongs.ci])
-  alex_up_bot_app_id = var.alex_up_bot_app_id
 }
 
 module "alex_g_bot_2_repository" {
@@ -15,5 +14,4 @@ module "alex_g_bot_2_repository" {
   visibility         = "public"
   archived           = true
   required_ci_checks = concat(local.check_list.base, [local.check_name.alex_g_bot.ci])
-  alex_up_bot_app_id = var.alex_up_bot_app_id
 }

--- a/services/github_organisation.tf
+++ b/services/github_organisation.tf
@@ -1,3 +1,7 @@
+data "github_app" "alex_up_bot" {
+  slug = "alex-up-bot"
+}
+
 module "github_organisation" {
   source      = "../modules/github/organisation"
   name        = "alextheman231"
@@ -10,7 +14,7 @@ module "github_organisation" {
   webhook_url   = var.webhook_url
 
   variables = {
-    ALEX_UP_BOT_APP_ID = var.alex_up_bot_app_id
+    ALEX_UP_BOT_APP_ID = data.github_app.alex_up_bot.id
   }
   secrets = {
     ALEX_UP_BOT_PRIVATE_KEY   = var.alex_up_bot_private_key

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -14,7 +14,6 @@ module "infrastructure_repository" {
     local.check_name.terraform.plan_ci,
     local.check_name.terraform.comment_plan
   ])
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   variables = {
     TF_CLOUD_ORGANIZATION = module.tfe_organisation.organisation_name
     TF_WORKSPACE          = module.infrastructure_workspace.workspace_name

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -7,7 +7,6 @@ module "lexicon" {
     local.check_name.lexicon.end_to_end_ci
   ])
   github_labels                     = merge(local.labels.standard, local.labels.app)
-  alex_up_bot_app_id                = var.alex_up_bot_app_id
   deployment_role_oidc_provider_arn = aws_iam_openid_connect_provider.github.arn
   lexicon_domain                    = var.lexicon_domain
   lexicon_google_client_id          = var.lexicon_google_client_id

--- a/services/lexicon/github.tf
+++ b/services/lexicon/github.tf
@@ -4,7 +4,6 @@ module "lexicon_repository" {
   description        = "The true successor to Neurosongs, allowing users to write blogs, share them, and track revision history."
   visibility         = "public"
   required_ci_checks = var.required_ci_checks
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   variables = {
     AWS_ROLE_ARN              = module.lexicon_deployment_role.role_arn
     AWS_CLUSTER_NAME          = module.lexicon_ecs_service.cluster_name

--- a/services/lexicon/variables.tf
+++ b/services/lexicon/variables.tf
@@ -18,11 +18,6 @@ variable "github_labels" {
   default = {}
 }
 
-variable "alex_up_bot_app_id" {
-  description = "App ID for alex-up-bot."
-  type        = string
-}
-
 variable "deployment_role_oidc_provider_arn" {
   description = "The OIDC provider ARN for the deployment role."
   type        = string

--- a/services/media.tf
+++ b/services/media.tf
@@ -4,6 +4,5 @@ module "media_repository" {
   description        = "Media used in my projects, often created with Manim."
   visibility         = "public"
   required_ci_checks = concat(local.check_list.base, [local.check_name.media.ci])
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   labels             = local.labels.standard
 }

--- a/services/music.tf
+++ b/services/music.tf
@@ -1,10 +1,9 @@
 module "music_repository" {
   source = "../modules/github/repository"
 
-  name               = "music"
-  description        = "My music projects."
-  visibility         = "public"
-  alex_up_bot_app_id = var.alex_up_bot_app_id
+  name        = "music"
+  description = "My music projects."
+  visibility  = "public"
   labels = {
     "breaking change" = {
       color       = "B60205"

--- a/services/packages.tf
+++ b/services/packages.tf
@@ -4,7 +4,6 @@ module "utility_repository" {
   description        = "A package to provide helpful utility functions to be used in most modern JavaScript/TypeScript projects."
   visibility         = "public"
   required_ci_checks = local.check_list.package
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   has_pages          = true
   labels             = local.labels.standard
 }
@@ -15,7 +14,6 @@ module "eslint_plugin_repository" {
   description        = "A package to provide custom ESLint rules and configs."
   visibility         = "public"
   required_ci_checks = local.check_list.package
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   labels             = local.labels.standard
 }
 
@@ -29,9 +27,8 @@ module "components_repository" {
     check
     if check != local.check_name.end_to_end_ci
   ], [local.check_name.components.end_to_end_ci])
-  has_pages          = true
-  alex_up_bot_app_id = var.alex_up_bot_app_id
-  labels             = merge(local.labels.standard, local.labels.package)
+  has_pages = true
+  labels    = merge(local.labels.standard, local.labels.package)
 }
 
 module "alex_c_line_repository" {
@@ -40,7 +37,6 @@ module "alex_c_line_repository" {
   description        = "Command-line tool with commands to streamline the developer workflow."
   visibility         = "public"
   required_ci_checks = concat(local.check_list.package, local.check_list.alex_c_line.legacy)
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   labels             = merge(local.labels.standard, local.labels.package)
 }
 
@@ -53,9 +49,8 @@ module "github_actions_repository" {
     local.check_list.github_actions.base,
     [local.check_name.github_actions.actions_ci, local.check_name.github_actions.version_change_ci]
   )
-  has_pages          = true
-  alex_up_bot_app_id = var.alex_up_bot_app_id
-  labels             = merge(local.labels.standard, local.labels.package)
+  has_pages = true
+  labels    = merge(local.labels.standard, local.labels.package)
 }
 
 module "typescript_actions_repository" {
@@ -64,6 +59,5 @@ module "typescript_actions_repository" {
   description        = "Composite actions developed in TypeScript to use in GitHub Actions workflows."
   visibility         = "public"
   required_ci_checks = concat(local.check_list.base, [local.check_name.package.source_code_ci])
-  alex_up_bot_app_id = var.alex_up_bot_app_id
   labels             = merge(local.labels.standard, local.labels.package)
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -3,11 +3,6 @@ variable "github_owner" {
   type        = string
 }
 
-variable "alex_up_bot_app_id" {
-  description = "App ID for alex-up-bot, commonly used to create pull requests in GitHub Actions. This should be used alongside alex_up_bot_private_key."
-  type        = string
-}
-
 variable "alex_up_bot_private_key" {
   description = "Private key for alex-up-bot app, commonly used to create pull requests in GitHub Actions."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "github_owner" {
   type        = string
 }
 
-variable "alex_up_bot_app_id" {
-  description = "App ID for alex-up-bot, commonly used to create pull requests in GitHub Actions. This should be used alongside alex_up_bot_private_key."
-  type        = string
-}
-
 variable "alex_up_bot_private_key" {
   description = "Private key for alex-up-bot app, commonly used to create pull requests in GitHub Actions."
   type        = string


### PR DESCRIPTION
This removes the need to pass it down to all created repositories, and also removes the need for it to be an HCP Terraform variable.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
