### PR TITLE
Add the initial S3 buckets for file store usage

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,6 +23,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.56.0"
   constraints = ">= 6.51.0"
   hashes = [
+    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
     "h1:iWz9BgFQaDPA1ChVGYvgI3MlUnx3wSQCA2ggYqDPcz8=",
     "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
     "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",

--- a/modules/aws/s3_bucket/main.tf
+++ b/modules/aws/s3_bucket/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}

--- a/modules/aws/s3_bucket/output.tf
+++ b/modules/aws/s3_bucket/output.tf
@@ -1,0 +1,9 @@
+output "arn" {
+  value = aws_s3_bucket.default.arn
+}
+
+output "name" {
+  value = aws_s3_bucket.default.bucket
+}
+
+

--- a/modules/aws/s3_bucket/resources.tf
+++ b/modules/aws/s3_bucket/resources.tf
@@ -1,0 +1,38 @@
+resource "aws_s3_bucket" "default" {
+  bucket = var.name
+}
+
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "default" {
+  bucket = aws_s3_bucket.default.id
+  count  = var.auto_delete_after_days > 0 ? 1 : 0
+
+  rule {
+    id     = "auto_expiration"
+    status = "Enabled"
+
+    expiration {
+      days = var.auto_delete_after_days
+    }
+
+    filter {}
+  }
+}

--- a/modules/aws/s3_bucket/variables.tf
+++ b/modules/aws/s3_bucket/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "Name of the bucket."
+  type        = string
+}
+
+variable "auto_delete_after_days" {
+  description = "The lifetime of the bucket's objects."
+  type        = number
+  default     = 0
+}

--- a/services/lexicon/file_store.tf
+++ b/services/lexicon/file_store.tf
@@ -1,0 +1,11 @@
+module "file_store" {
+  source = "../../modules/aws/s3_bucket"
+
+  name = "lexicon-files"
+}
+
+module "file_store_dev" {
+  source = "../../modules/aws/s3_bucket"
+
+  name = "lexicon-files-dev"
+}


### PR DESCRIPTION
They won't be accessible just yet - I will need to configure the ECS task role before that. This will be done in the next pull request.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
