### PR TITLE
Use a different name for the production file store

### DIFF
--- a/services/lexicon/file_store.tf
+++ b/services/lexicon/file_store.tf
@@ -1,7 +1,7 @@
-module "file_store" {
+module "file_store_prod" {
   source = "../../modules/aws/s3_bucket"
 
-  name = "lexicon-files"
+  name = "lexicon-files-prod"
 }
 
 module "file_store_dev" {


### PR DESCRIPTION
For some reason lexicon-files was considered already taken? I think it might be because of lexicon-files-dev also starting with lexicon-files and so it recognises that lexicon-files alone is part of the same namespace? Hopefully this fixes it, though...

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
