### PR TITLE
Rename the task execution role back from lexicon-london to just lexicon

### DIFF
--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -1,6 +1,6 @@
 module "lexicon_ecs_task_execution_role" {
   source      = "../../modules/aws/roles/ecs_task_execution"
-  name        = "lexicon-london"
+  name        = "lexicon"
   secret_arns = module.lexicon_secrets.secret_arns
 }
 


### PR DESCRIPTION
The London deployment is now the only deployed version so the extra -london is not needed.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
