### PR TITLE
Change the AMI filter to be more precise

### DIFF
--- a/services/lexicon/ec2.tf
+++ b/services/lexicon/ec2.tf
@@ -5,7 +5,7 @@ data "aws_ami" "amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-*-kernel-*-arm64"]
+    values = ["al2023-ami-20*-kernel-*-arm64"]
   }
 }
 


### PR DESCRIPTION
I think the systems manager isn't showing up yet because it's using the minimal AMI, whereas we want it to use one of the standard ones.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
