### PR TITLE
Add an initial configuration for my new Discord server

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -133,3 +133,19 @@ provider "registry.terraform.io/jianyuan/sentry" {
     "zh:ff718ef3559083d8fd625d13a7841ef6e42be0dbe000446536351354eb7c5004",
   ]
 }
+
+provider "registry.terraform.io/unkso/discord" {
+  version     = "2.7.1"
+  constraints = ">= 2.7.1"
+  hashes = [
+    "h1:/sO9huHyTDCX5DDRi4WRKYlnkLUTnheDPFcB6pOzSuo=",
+    "zh:68cebc939c64103b800f16be3f7f9a00ba52b1db00268658e0ecc3297c31bc7b",
+    "zh:73184206bd471b131924399dc1dcbc5e59c5e7d975cf4e9054585326516020cc",
+    "zh:984cb1ea8e76084526bd304cd3dbd6ff2d39f6e37dc28d6816f6672babb31e36",
+    "zh:a7a58db21195b071402e6b76993fc48c3b62d1c476bc0d24e3bfcde945ef155c",
+    "zh:acfdfea2569caf4817cca2062bcf5cfc617a5585783829e7e6fe8f5624401140",
+    "zh:b74375fe542253fd71ee34746781bf552819f77a5ec88658714890a5aa7695a4",
+    "zh:c99080b9e1690831b1d6a25a01671345d769605ee7d39e9dd2f3a8304aa78f2f",
+    "zh:e89cf22dd1f80148a0d88302e2482c6a311b12e040abfe5938ed4a6b42428659",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -32,4 +32,5 @@ module "services" {
   cloudflare_api_token                       = var.cloudflare_api_token
   lexicon_database_password                  = var.lexicon_database_password
   public_ssh_key                             = var.public_ssh_key
+  discord_token                              = var.discord_token
 }

--- a/services/alextheman231_discord_server.tf
+++ b/services/alextheman231_discord_server.tf
@@ -1,0 +1,5 @@
+module "alextheman231_discord_server" {
+  source = "./alextheman231_discord_server"
+
+  server_id = "1531070585562468382"
+}

--- a/services/alextheman231_discord_server/colours.tf
+++ b/services/alextheman231_discord_server/colours.tf
@@ -1,0 +1,3 @@
+data "discord_color" "red" {
+  hex = "#ff0000"
+}

--- a/services/alextheman231_discord_server/main.tf
+++ b/services/alextheman231_discord_server/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    discord = {
+      source  = "unkso/discord"
+      version = ">=2.7.1"
+    }
+  }
+}

--- a/services/alextheman231_discord_server/permissions.tf
+++ b/services/alextheman231_discord_server/permissions.tf
@@ -1,0 +1,3 @@
+data "discord_permission" "owner" {
+  administrator = "allow"
+}

--- a/services/alextheman231_discord_server/role_assignments.tf
+++ b/services/alextheman231_discord_server/role_assignments.tf
@@ -1,0 +1,13 @@
+data "discord_member" "alex_the_man_231" {
+  server_id = var.server_id
+  user_id   = "690281795618734330"
+}
+
+resource "discord_member_roles" "alex" {
+  user_id   = data.discord_member.alex_the_man_231.id
+  server_id = var.server_id
+
+  role {
+    role_id = discord_role.owner.id
+  }
+}

--- a/services/alextheman231_discord_server/roles.tf
+++ b/services/alextheman231_discord_server/roles.tf
@@ -1,0 +1,8 @@
+resource "discord_role" "owner" {
+  name        = "Owner"
+  server_id   = var.server_id
+  color       = data.discord_color.red.dec
+  hoist       = true
+  mentionable = true
+  permissions = data.discord_permission.owner.allow_bits
+}

--- a/services/alextheman231_discord_server/variables.tf
+++ b/services/alextheman231_discord_server/variables.tf
@@ -1,0 +1,3 @@
+variable "server_id" {
+  type = string
+}

--- a/services/main.tf
+++ b/services/main.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">=3.9.0"
     }
+    discord = {
+      source  = "unkso/discord"
+      version = ">=2.7.1"
+    }
   }
 }
 
@@ -51,4 +55,8 @@ provider "cloudflare" {
 
 provider "aws" {
   region = local.aws_region
+}
+
+provider "discord" {
+  token = var.discord_token
 }

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -107,3 +107,9 @@ variable "public_ssh_key" {
   description = "My public SSH key"
   type        = string
 }
+
+variable "discord_token" {
+  description = "Discord token to help manage my Discord infrastructure."
+  type        = string
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "public_ssh_key" {
   description = "My public SSH key"
   type        = string
 }
+
+variable "discord_token" {
+  description = "Discord token to help manage my Discord infrastructure."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Unfortunately it cannot be imported into the configuration due to a provider bug, so the server_id must be hardcoded. For now, this will at least create the owner role and assign it to me.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
