### PR TITLE
Only allow bots to send messages to admin channels

### DIFF
--- a/services/alextheman231_discord_server/category_permissions.tf
+++ b/services/alextheman231_discord_server/category_permissions.tf
@@ -1,0 +1,13 @@
+resource "discord_channel_permission" "admin_category_everyone" {
+  channel_id   = discord_category_channel.admin.id
+  allow        = data.discord_permission.no_send_messages.allow_bits
+  type         = "role"
+  overwrite_id = discord_role_everyone.default.id
+}
+
+resource "discord_channel_permission" "admin_category_bot" {
+  channel_id   = discord_category_channel.admin.id
+  allow        = data.discord_permission.send_messages.allow_bits
+  type         = "role"
+  overwrite_id = discord_role.bot.id
+}

--- a/services/alextheman231_discord_server/colours.tf
+++ b/services/alextheman231_discord_server/colours.tf
@@ -1,3 +1,7 @@
 data "discord_color" "red" {
   hex = "#ff0000"
 }
+
+data "discord_color" "blue" {
+  hex = "#0000ff"
+}

--- a/services/alextheman231_discord_server/permissions.tf
+++ b/services/alextheman231_discord_server/permissions.tf
@@ -1,3 +1,23 @@
 data "discord_permission" "owner" {
   administrator = "allow"
 }
+
+data "discord_permission" "bot" {
+  view_channel          = "allow"
+  manage_channels       = "allow"
+  manage_roles          = "allow"
+  manage_webhooks       = "allow"
+  manage_guild          = "allow"
+  create_instant_invite = "allow"
+  change_nickname       = "allow"
+  manage_nicknames      = "allow"
+  send_messages         = "allow"
+}
+
+data "discord_permission" "no_send_messages" {
+  send_messages = "deny"
+}
+
+data "discord_permission" "send_messages" {
+  send_messages = "allow"
+}

--- a/services/alextheman231_discord_server/role_assignments.tf
+++ b/services/alextheman231_discord_server/role_assignments.tf
@@ -3,11 +3,25 @@ data "discord_member" "alex_the_man_231" {
   user_id   = "690281795618734330"
 }
 
+data "discord_member" "alex_infrastructure_bot" {
+  server_id = var.server_id
+  user_id   = "1531066057593196675"
+}
+
 resource "discord_member_roles" "alex" {
   user_id   = data.discord_member.alex_the_man_231.id
   server_id = var.server_id
 
   role {
     role_id = discord_role.owner.id
+  }
+}
+
+resource "discord_member_roles" "alex_infrastructure_bot" {
+  user_id   = data.discord_member.alex_infrastructure_bot.id
+  server_id = var.server_id
+
+  role {
+    role_id = discord_role.bot.id
   }
 }

--- a/services/alextheman231_discord_server/roles.tf
+++ b/services/alextheman231_discord_server/roles.tf
@@ -6,3 +6,16 @@ resource "discord_role" "owner" {
   mentionable = true
   permissions = data.discord_permission.owner.allow_bits
 }
+
+resource "discord_role" "bot" {
+  name        = "Bot"
+  server_id   = var.server_id
+  color       = data.discord_color.blue.dec
+  hoist       = true
+  mentionable = true
+  permissions = data.discord_permission.bot.allow_bits
+}
+
+resource "discord_role_everyone" "default" {
+  server_id = var.server_id
+}


### PR DESCRIPTION
Admin channels are more for server information rather than for general use. As such, regular members should not be able to send messages to those channels.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
