### PR TITLE
Create a read-only user for myself

### DIFF
--- a/modules/aws/iam_user/read_only_user/main.tf
+++ b/modules/aws/iam_user/read_only_user/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.51.0"
+    }
+  }
+}

--- a/modules/aws/iam_user/read_only_user/outputs.tf
+++ b/modules/aws/iam_user/read_only_user/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = aws_iam_user.read_only.name
+}
+
+output "arn" {
+  value = aws_iam_user.read_only.arn
+}

--- a/modules/aws/iam_user/read_only_user/resources.tf
+++ b/modules/aws/iam_user/read_only_user/resources.tf
@@ -1,0 +1,18 @@
+resource "aws_iam_user" "read_only" {
+  name = var.name
+  path = "/"
+}
+
+resource "aws_iam_user_login_profile" "read_only" {
+  user = aws_iam_user.read_only.name
+}
+
+
+data "aws_iam_policy" "read_only_access" {
+  arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "read_only" {
+  policy_arn = data.aws_iam_policy.read_only_access.arn
+  user       = aws_iam_user.read_only.name
+}

--- a/modules/aws/iam_user/read_only_user/variables.tf
+++ b/modules/aws/iam_user/read_only_user/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  description = "The name of the user."
+  type        = string
+}

--- a/services/aws.tf
+++ b/services/aws.tf
@@ -1,9 +1,0 @@
-locals {
-  aws_region = "eu-west-2"
-}
-
-module "alex_iam_user" {
-  source = "../modules/aws/iam_user/power_user"
-
-  name = "alextheman231"
-}

--- a/services/aws_region.tf
+++ b/services/aws_region.tf
@@ -1,0 +1,3 @@
+locals {
+  aws_region = "eu-west-2"
+}

--- a/services/aws_users.tf
+++ b/services/aws_users.tf
@@ -1,0 +1,11 @@
+module "alex_iam_user" {
+  source = "../modules/aws/iam_user/power_user"
+
+  name = "alextheman231"
+}
+
+module "alex_iam_read_only_user" {
+  source = "../modules/aws/iam_user/read_only_user"
+
+  name = "alextheman231_readonly"
+}


### PR DESCRIPTION
So I can test that the session manager permissions are correctly scoped, and read-only users can't access the database.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
