### PR TITLE
Add recovery_window_in_days = 0 to secrets manager setup

### DIFF
--- a/modules/aws/secrets_manager/resources.tf
+++ b/modules/aws/secrets_manager/resources.tf
@@ -1,5 +1,6 @@
 resource "aws_secretsmanager_secret" "default" {
-  name = var.name
+  name                    = var.name
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "default" {


### PR DESCRIPTION
This ensures that, if the secret ever needs fully replacing, it shouldn't error due to the recovery window being present.