### PR TITLE
Give the iam:PassRole permission to the task role

### DIFF
--- a/services/lexicon/github.tf
+++ b/services/lexicon/github.tf
@@ -50,7 +50,8 @@ data "aws_iam_policy_document" "lexicon_deploy" {
     ]
 
     resources = [
-      module.lexicon_ecs_task_execution_role.role_arn
+      module.lexicon_ecs_task_execution_role.role_arn,
+      module.lexicon_ecs_task_role.role_arn
     ]
   }
 }


### PR DESCRIPTION
This is needed to allow the deployment role to use the ECS task role, otherwise deployment fails.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
