### PR TITLE
Add create_before_destroy to the database subnet group

### DIFF
--- a/modules/aws/network/resources.tf
+++ b/modules/aws/network/resources.tf
@@ -106,4 +106,8 @@ resource "aws_db_subnet_group" "default" {
   tags = {
     Name = var.name
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
Otherwise it will try and destroy the subnet group while it is still being used, whereas if we let it create first it will ensure the new one is used before removing the old one.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
