### PR TITLE
Revert "Make the network part of the common AWS setup"

### DIFF
--- a/services/aws_network.tf
+++ b/services/aws_network.tf
@@ -1,9 +1,0 @@
-module "aws_network" {
-  source = "../modules/aws/network"
-  name   = "alextheman231"
-}
-
-moved {
-  from = module.lexicon.module.lexicon_network
-  to   = module.aws_network
-}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -17,3 +17,8 @@ module "lexicon" {
   sentry_organisation_id            = module.sentry_organisation.id
   sentry_github_integration_id      = module.sentry_organisation.github_integration_id
 }
+
+moved {
+  from = module.aws_network
+  to   = module.lexicon.module.lexicon_network
+}

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -16,8 +16,4 @@ module "lexicon" {
   aws_region                        = local.aws_region
   sentry_organisation_id            = module.sentry_organisation.id
   sentry_github_integration_id      = module.sentry_organisation.github_integration_id
-  vpc_id                            = module.aws_network.vpc_id
-  public_subnet_ids                 = module.aws_network.public_subnet_ids
-  private_subnet_ids                = module.aws_network.private_subnet_ids
-  db_subnet_group_name              = module.aws_network.db_subnet_group_name
 }

--- a/services/lexicon/database.tf
+++ b/services/lexicon/database.tf
@@ -5,6 +5,6 @@ module "lexicon_database" {
   postgres_version     = "18"
   username             = "lexicon_user"
   password             = var.lexicon_database_password
-  db_subnet_group_name = var.db_subnet_group_name
+  db_subnet_group_name = module.lexicon_network.db_subnet_group_name
   security_group_ids   = [module.lexicon_database_security_group.id]
 }

--- a/services/lexicon/ec2.tf
+++ b/services/lexicon/ec2.tf
@@ -19,7 +19,7 @@ module "session_management" {
   source               = "../../modules/aws/ec2"
   ami                  = data.aws_ami.amazon_linux.id
   name                 = "lexicon-session-management"
-  subnet_id            = var.private_subnet_ids[0]
+  subnet_id            = module.lexicon_network.private_subnet_ids[0]
   security_group_ids   = [module.lexicon_session_management_security_group.id]
   iam_instance_profile = module.session_management_role.profile_name
 }

--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -14,8 +14,8 @@ module "lexicon_ecs_task_role" {
 module "lexicon_ecs_service" {
   source = "../../modules/aws/ecs"
 
-  vpc_id     = var.vpc_id
-  subnet_ids = var.private_subnet_ids
+  vpc_id     = module.lexicon_network.vpc_id
+  subnet_ids = module.lexicon_network.private_subnet_ids
   name       = "lexicon"
   image      = module.lexicon_ecr_image.repository_url
   port       = local.backend_port

--- a/services/lexicon/load_balancer.tf
+++ b/services/lexicon/load_balancer.tf
@@ -37,7 +37,7 @@ module "lexicon_load_balancer" {
   health_check_path  = "/api/v1"
   port               = local.backend_port
   certificate_arn    = module.lexicon_acm_certificate_validation.validated_certificate_arn
-  vpc_id             = var.vpc_id
-  subnet_ids         = var.public_subnet_ids
+  vpc_id             = module.lexicon_network.vpc_id
+  subnet_ids         = module.lexicon_network.public_subnet_ids
   security_group_ids = [module.lexicon_load_balancer_security_group.id]
 }

--- a/services/lexicon/network.tf
+++ b/services/lexicon/network.tf
@@ -1,0 +1,4 @@
+module "lexicon_network" {
+  source = "../../modules/aws/network"
+  name   = "lexicon"
+}

--- a/services/lexicon/security_groups.tf
+++ b/services/lexicon/security_groups.tf
@@ -2,26 +2,26 @@ module "lexicon_database_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-prod-database"
-  vpc_id = var.vpc_id
+  vpc_id = module.lexicon_network.vpc_id
 }
 
 module "lexicon_session_management_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-session-management"
-  vpc_id = var.vpc_id
+  vpc_id = module.lexicon_network.vpc_id
 }
 
 module "lexicon_load_balancer_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-alb"
-  vpc_id = var.vpc_id
+  vpc_id = module.lexicon_network.vpc_id
 }
 
 module "lexicon_ecs_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-ecs"
-  vpc_id = var.vpc_id
+  vpc_id = module.lexicon_network.vpc_id
 }

--- a/services/lexicon/variables.tf
+++ b/services/lexicon/variables.tf
@@ -63,23 +63,3 @@ variable "sentry_github_integration_id" {
   description = "The ID for the integration between the Sentry organisation and GitHub."
   type        = string
 }
-
-variable "vpc_id" {
-  description = "The VPC ID."
-  type        = string
-}
-
-variable "public_subnet_ids" {
-  description = "The public subnet IDs."
-  type        = list(string)
-}
-
-variable "private_subnet_ids" {
-  description = "The private subnet IDs."
-  type        = list(string)
-}
-
-variable "db_subnet_group_name" {
-  description = "The name of the subnet group associated with the database."
-  type        = string
-}


### PR DESCRIPTION
This reverts commit 41cac362788299d505dffdf0c73fa7861bea88d3.

There is a very cursed thing where we have a deposed subnet group. As such, let's see if reverting the networking changes will fix the issue for now while we try and fix it properly.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
