### PR TITLE
Move the secrets manager role policy inside the secrets manager itself

### DIFF
--- a/modules/aws/roles/ecs_task_execution/outputs.tf
+++ b/modules/aws/roles/ecs_task_execution/outputs.tf
@@ -1,3 +1,7 @@
 output "role_arn" {
   value = aws_iam_role.ecs_task_execution.arn
 }
+
+output "role_id" {
+  value = aws_iam_role.ecs_task_execution.id
+}

--- a/modules/aws/roles/ecs_task_execution/resources.tf
+++ b/modules/aws/roles/ecs_task_execution/resources.tf
@@ -20,24 +20,3 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
   role       = aws_iam_role.ecs_task_execution.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
-
-resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
-  count = length(var.secret_arns) > 0 ? 1 : 0
-
-  name = "${var.name}-ecs-task-execution-secrets"
-  role = aws_iam_role.ecs_task_execution.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-
-    Statement = [{
-      Effect = "Allow"
-
-      Action = [
-        "secretsmanager:GetSecretValue"
-      ]
-
-      Resource = distinct(values(var.secret_arns))
-    }]
-  })
-}

--- a/modules/aws/roles/terraform/outputs.tf
+++ b/modules/aws/roles/terraform/outputs.tf
@@ -2,6 +2,10 @@ output "role_name" {
   value = aws_iam_role.role.name
 }
 
+output "role_id" {
+  value = aws_iam_role.role.id
+}
+
 output "role_arn" {
   value = aws_iam_role.role.arn
 }

--- a/modules/aws/secrets_manager/resources.tf
+++ b/modules/aws/secrets_manager/resources.tf
@@ -7,3 +7,26 @@ resource "aws_secretsmanager_secret_version" "default" {
   secret_id     = aws_secretsmanager_secret.default.id
   secret_string = jsonencode(var.secrets)
 }
+
+resource "aws_iam_role_policy" "secret_access" {
+  for_each = merge(var.allowed_role_ids, {
+    terraform_plan_role = var.plan_role_id
+  })
+
+  name = "${each.key}-${var.name}-secrets-access"
+  role = each.value
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+
+      Action = [
+        "secretsmanager:GetSecretValue"
+      ]
+
+      Resource = aws_secretsmanager_secret.default.arn
+    }]
+  })
+}

--- a/modules/aws/secrets_manager/variables.tf
+++ b/modules/aws/secrets_manager/variables.tf
@@ -8,3 +8,14 @@ variable "secrets" {
   type        = map(string)
   sensitive   = true
 }
+
+variable "plan_role_id" {
+  description = "The Terraform plan role ID."
+  type        = string
+}
+
+variable "allowed_role_ids" {
+  description = "Role IDs to allow secret access to."
+  type        = map(string)
+  default     = {}
+}

--- a/services/infrastructure.tf
+++ b/services/infrastructure.tf
@@ -37,23 +37,6 @@ module "terraform_plan_role" {
   run_phase = "plan"
 }
 
-data "aws_iam_policy_document" "plan_secret_access" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "secretsmanager:GetSecretValue"
-    ]
-
-    resources = [module.lexicon.secret_manager_arn]
-  }
-}
-
-resource "aws_iam_role_policy" "plan_secret_access" {
-  role   = module.terraform_plan_role.role_name
-  policy = data.aws_iam_policy_document.plan_secret_access.json
-}
-
 resource "aws_iam_role_policy_attachment" "readonly" {
   role       = module.terraform_plan_role.role_name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"

--- a/services/lexicon.tf
+++ b/services/lexicon.tf
@@ -19,4 +19,5 @@ module "lexicon" {
   vpc_id                            = module.aws_network.vpc_id
   public_subnet_ids                 = module.aws_network.public_subnet_ids
   private_subnet_ids                = module.aws_network.private_subnet_ids
+  plan_role_id                      = module.terraform_plan_role.role_id
 }

--- a/services/lexicon/secrets.tf
+++ b/services/lexicon/secrets.tf
@@ -5,4 +5,8 @@ module "lexicon_secrets" {
     DATABASE_URL         = module.lexicon_database.database_url
     GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
   }
+  plan_role_id = var.plan_role_id
+  allowed_role_ids = {
+    ecs_task_execution = module.lexicon_ecs_task_execution_role.role_id
+  }
 }

--- a/services/lexicon/variables.tf
+++ b/services/lexicon/variables.tf
@@ -78,3 +78,8 @@ variable "private_subnet_ids" {
   description = "The private subnet IDs."
   type        = list(string)
 }
+
+variable "plan_role_id" {
+  description = "The Terraform plan role ID."
+  type        = string
+}


### PR DESCRIPTION
This allows the module itself to handle role permissions natively, rather than call sites needing to wire it up themselves. It also means that we can enforce that the plan role must be passed into the secrets manager, which is needed otherwise the plan after the apply will fail due to insufficient permissions.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
