### PR TITLE
Use the repository full name from the provided output

### DIFF
--- a/modules/github/repository/outputs.tf
+++ b/modules/github/repository/outputs.tf
@@ -1,0 +1,3 @@
+output "full_name" {
+  value = github_repository.default.full_name
+}

--- a/services/lexicon/github.tf
+++ b/services/lexicon/github.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "lexicon_deploy" {
 
 module "lexicon_deployment_role" {
   source            = "../../modules/aws/roles/github"
-  repository        = "alextheman231/lexicon"
+  repository        = module.lexicon_repository.full_name
   role_name         = "lexicon-deployment"
   oidc_provider_arn = var.deployment_role_oidc_provider_arn
   policy_json       = data.aws_iam_policy_document.lexicon_deploy.json

--- a/services/lexicon/monitoring.tf
+++ b/services/lexicon/monitoring.tf
@@ -2,7 +2,7 @@ resource "sentry_organization_repository" "github" {
   organization     = var.sentry_organisation_id
   integration_type = "github"
   integration_id   = var.sentry_github_integration_id
-  identifier       = "alextheman231/lexicon"
+  identifier       = module.lexicon_repository.full_name
 }
 
 module "lexicon_sentry_back_end" {


### PR DESCRIPTION
It ensures that usage of the repository full name is kept consistent and never goes out-of-sync.

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
