### PR TITLE
Correct the Redis endpoint

### DIFF
--- a/modules/aws/redis/outputs.tf
+++ b/modules/aws/redis/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = aws_elasticache_cluster.default.configuration_endpoint
+  value = aws_elasticache_cluster.default.cache_nodes[0].address
 }


### PR DESCRIPTION
configuration_endpoint is not actually compatible with Redis and so using that does not give us the actual endpoint. Instead, it is located on the address of the first of the cache_nodes.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
