### PR TITLE
Remove ALLOWED_ORIGINS environment variable

### DIFF
--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -22,7 +22,6 @@ module "lexicon_ecs_service" {
   environment_variables = {
     NODE_ENV         = "production"
     API_BASE_URL     = "https://${var.lexicon_domain}"
-    ALLOWED_ORIGINS  = "https://${var.lexicon_domain}"
     GOOGLE_CLIENT_ID = var.lexicon_google_client_id
     SENTRY_DSN       = module.lexicon_sentry_back_end.public_dsn
     REDIS_URL        = module.redis.endpoint


### PR DESCRIPTION
It isn't needed now that we serve the front-end as static files from the back-end.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
