### PR TITLE
Add the file store bucket name as an environment variable

### DIFF
--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -20,11 +20,12 @@ module "lexicon_ecs_service" {
   image      = module.lexicon_ecr_image.repository_url
   port       = local.backend_port
   environment_variables = {
-    NODE_ENV         = "production"
-    API_BASE_URL     = "https://${var.lexicon_domain}"
-    GOOGLE_CLIENT_ID = var.lexicon_google_client_id
-    SENTRY_DSN       = module.lexicon_sentry_back_end.public_dsn
-    REDIS_URL        = module.redis.endpoint
+    NODE_ENV               = "production"
+    API_BASE_URL           = "https://${var.lexicon_domain}"
+    GOOGLE_CLIENT_ID       = var.lexicon_google_client_id
+    SENTRY_DSN             = module.lexicon_sentry_back_end.public_dsn
+    REDIS_URL              = module.redis.endpoint
+    FILE_STORE_BUCKET_NAME = module.file_store_prod.name
   }
   secret_arns     = module.lexicon_secrets.secret_arns
   fargate_version = "1.4.0"


### PR DESCRIPTION
So we can set up the file store integration in Lexicon.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
