### PR TITLE
Add a private music repository for my WIP music projects

### DIFF
--- a/services/music.tf
+++ b/services/music.tf
@@ -32,3 +32,12 @@ module "music_repository" {
     }
   }
 }
+
+module "music_repository_dev" {
+  source = "../modules/github/repository"
+
+  name               = "music-dev"
+  description        = "My WIP music projects."
+  visibility         = "private"
+  alex_up_bot_app_id = var.alex_up_bot_app_id
+}


### PR DESCRIPTION
My WiP music projects most likely shouldn't be in the public music repository given that it is publicly accessible. As such, it would be better to give myself a private repository to work on new material in and use that to keep backups, and then once it's ready for public release we can then move it to the public music repository.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
