### PR TITLE
Attempt to fix the availability zones causing state drift

### DIFF
--- a/modules/aws/network/data.tf
+++ b/modules/aws/network/data.tf
@@ -1,3 +1,13 @@
 data "aws_availability_zones" "available" {
   state = "available"
+
+  filter {
+    name   = "zone-type"
+    values = ["availability-zone"]
+  }
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }

--- a/modules/aws/network/locals.tf
+++ b/modules/aws/network/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  subnet_count = min(4, length(data.aws_availability_zones.available.names))
+  subnet_count = 3
 }


### PR DESCRIPTION
There is a very bad state drift happening right now where the availability zones data source is changing the exact subnets we are using, which is also then planning to recreate pretty much the entire AWS setup. The hope is that adding these extra filters will help it be more specific and hopefully match what it was before.

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
