### PR TITLE
Do not create GitHub repository rulesets if the repository is private

### DIFF
--- a/modules/github/repository/rulesets.tf
+++ b/modules/github/repository/rulesets.tf
@@ -1,5 +1,5 @@
 resource "github_branch_protection" "linear_history" {
-  count                   = !var.archived ? 1 : 0
+  count                   = !var.archived && var.visibility == "public" ? 1 : 0
   repository_id           = github_repository.default.name
   pattern                 = "*"
   required_linear_history = true
@@ -8,7 +8,7 @@ resource "github_branch_protection" "linear_history" {
 }
 
 resource "github_repository_ruleset" "ci_checks" {
-  count       = length(var.required_ci_checks) > 0 && !var.archived ? 1 : 0
+  count       = length(var.required_ci_checks) > 0 && !var.archived && var.visibility == "public" ? 1 : 0
   name        = "CI checks to run on main"
   repository  = github_repository.default.name
   target      = "branch"
@@ -42,7 +42,7 @@ resource "github_repository_ruleset" "ci_checks" {
 
 
 resource "github_repository_ruleset" "no_deletion_or_force_push" {
-  count       = !var.archived ? 1 : 0
+  count       = !var.archived && var.visibility == "public" ? 1 : 0
   name        = "Protect main from being deleted/force-pushed"
   repository  = github_repository.default.name
   target      = "branch"
@@ -62,7 +62,7 @@ resource "github_repository_ruleset" "no_deletion_or_force_push" {
 }
 
 resource "github_repository_ruleset" "pull_request_conditions" {
-  count       = !var.archived ? 1 : 0
+  count       = !var.archived && var.visibility == "public" ? 1 : 0
   name        = "Pull request conditions (bypassable by admins)"
   repository  = github_repository.default.name
   target      = "branch"
@@ -91,7 +91,7 @@ resource "github_repository_ruleset" "pull_request_conditions" {
 }
 
 resource "github_repository_ruleset" "restrict_version_tags" {
-  count       = !var.archived ? 1 : 0
+  count       = !var.archived && var.visibility == "public" ? 1 : 0
   name        = "Restriction against creating version tags (bypassable by alex-up-bot)"
   repository  = github_repository.default.name
   target      = "tag"


### PR DESCRIPTION
They can't be created on private repositories unless we are on GitHub Pro, which we are currently not (yet, anyway).

# Bug Fix

This is a bug fix for `infrastructure`. It fixes an unintended side-effect of the configuration or deployment.

Please see the commits tab of this pull request for the description of changes.
