### PR TITLE
Disable auto merge on private repositories

### DIFF
--- a/modules/github/repository/repository.tf
+++ b/modules/github/repository/repository.tf
@@ -7,7 +7,7 @@ resource "github_repository" "default" {
   has_projects = var.has_projects
   has_wiki     = var.has_wiki
 
-  allow_auto_merge       = true
+  allow_auto_merge       = var.visibility == "public"
   allow_merge_commit     = true
   allow_rebase_merge     = true
   allow_squash_merge     = false


### PR DESCRIPTION
I don't think we can do this on a non-pro plan.

# Resource Update

This is a change to an existing resource in `infrastructure` in the Terraform plan. It changes the currently managed state without removing or adding anything else to the plan.

Please see the commits tab of this pull request for the description of changes.
