### PR TITLE
Add the base checks to the music repository

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,4 +1,4 @@
-name: Check labels (Internal)
+name: Check labels
 
 on:
   pull_request:

--- a/services/music.tf
+++ b/services/music.tf
@@ -5,6 +5,7 @@ module "music_repository" {
   description        = "My music projects."
   visibility         = "public"
   alex_up_bot_app_id = var.alex_up_bot_app_id
+  required_ci_checks = local.check_list.base
   labels = {
     "breaking change" = {
       color       = "B60205"


### PR DESCRIPTION
I think it should have these - all these will do is check for and restrict alex-up-bot branches, check that pull requests are properly labelled, and lint the base workflows, which feel like reasonable workflows to have despite the LFS stuff otherwise. They don't exist there just yet but I will add them.

# New Feature

This is a new feature for `infrastructure` that adds a new Terraform-managed resource.

Please see the commits tab of this pull request for the description of changes.
