### PR TITLE
Remove lexicon prefix from Terraform resources where appropriate

### DIFF
--- a/services/lexicon/database.tf
+++ b/services/lexicon/database.tf
@@ -1,10 +1,15 @@
-module "lexicon_database" {
+module "database" {
   source             = "../../modules/aws/database"
   initial_db_name    = "lexicon"
   db_identifier      = "lexicon-prod"
   postgres_version   = "18"
   username           = "lexicon_user"
   password           = var.lexicon_database_password
-  security_group_ids = [module.lexicon_database_security_group.id]
+  security_group_ids = [module.database_security_group.id]
   subnet_ids         = var.private_subnet_ids
+}
+
+moved {
+  from = module.lexicon_database
+  to   = module.database
 }

--- a/services/lexicon/dns.tf
+++ b/services/lexicon/dns.tf
@@ -4,7 +4,7 @@ data "cloudflare_zone" "lexicon_domain" {
   }
 }
 
-module "lexicon_dns_record" {
+module "dns_record" {
   source = "../../modules/cloudflare/dns"
   for_each = toset([
     var.lexicon_domain,
@@ -14,10 +14,20 @@ module "lexicon_dns_record" {
   name    = each.value
   type    = "CNAME"
   zone_id = data.cloudflare_zone.lexicon_domain.zone_id
-  content = module.lexicon_load_balancer.dns_name
+  content = module.load_balancer.dns_name
 }
 
-resource "cloudflare_zone_dnssec" "lexicon_domain" {
+resource "cloudflare_zone_dnssec" "domain" {
   zone_id = data.cloudflare_zone.lexicon_domain.zone_id
   status  = "active"
+}
+
+moved {
+  from = module.lexicon_dns_record
+  to   = module.dns_record
+}
+
+moved {
+  from = cloudflare_zone_dnssec.lexicon_domain
+  to   = cloudflare_zone_dnssec.domain
 }

--- a/services/lexicon/ec2.tf
+++ b/services/lexicon/ec2.tf
@@ -20,6 +20,6 @@ module "session_management" {
   ami                  = data.aws_ami.amazon_linux.id
   name                 = "lexicon-session-management"
   subnet_id            = var.private_subnet_ids[0]
-  security_group_ids   = [module.lexicon_session_management_security_group.id]
+  security_group_ids   = [module.session_management_security_group.id]
   iam_instance_profile = module.session_management_role.profile_name
 }

--- a/services/lexicon/ecs.tf
+++ b/services/lexicon/ecs.tf
@@ -1,33 +1,33 @@
-module "lexicon_ecs_task_execution_role" {
+module "ecs_task_execution_role" {
   source      = "../../modules/aws/iam/roles/ecs_task_execution"
   name        = "lexicon"
-  secret_arns = module.lexicon_secrets.secret_arns
+  secret_arns = module.secrets.secret_arns
 }
 
-module "lexicon_ecs_task_role" {
+module "ecs_task_role" {
   source = "../../modules/aws/iam/roles/ecs_task"
 
   name           = "lexicon"
   s3_bucket_arns = [module.file_store_prod.arn, module.file_store_dev.arn]
 }
 
-module "lexicon_ecs_service" {
+module "ecs_service" {
   source = "../../modules/aws/ecs"
 
   vpc_id     = var.vpc_id
   subnet_ids = var.private_subnet_ids
   name       = "lexicon"
-  image      = module.lexicon_ecr_image.repository_url
+  image      = module.ecr_image.repository_url
   port       = local.backend_port
   environment_variables = {
     NODE_ENV               = "production"
     API_BASE_URL           = "https://${var.lexicon_domain}"
     GOOGLE_CLIENT_ID       = var.lexicon_google_client_id
-    SENTRY_DSN             = module.lexicon_sentry_back_end.public_dsn
+    SENTRY_DSN             = module.sentry_back_end.public_dsn
     REDIS_URL              = module.redis.endpoint
     FILE_STORE_BUCKET_NAME = module.file_store_prod.name
   }
-  secret_arns     = module.lexicon_secrets.secret_arns
+  secret_arns     = module.secrets.secret_arns
   fargate_version = "1.4.0"
 
   task_definitions = [{
@@ -40,9 +40,24 @@ module "lexicon_ecs_service" {
   ]
   region = var.aws_region
 
-  target_group_arn   = module.lexicon_load_balancer.target_group_arn
-  lb_listener_arn    = module.lexicon_load_balancer.listener_arn
-  execution_role_arn = module.lexicon_ecs_task_execution_role.role_arn
-  task_role_arn      = module.lexicon_ecs_task_role.role_arn
-  security_group_ids = [module.lexicon_ecs_security_group.id]
+  target_group_arn   = module.load_balancer.target_group_arn
+  lb_listener_arn    = module.load_balancer.listener_arn
+  execution_role_arn = module.ecs_task_execution_role.role_arn
+  task_role_arn      = module.ecs_task_role.role_arn
+  security_group_ids = [module.ecs_security_group.id]
+}
+
+moved {
+  from = module.lexicon_ecs_task_execution_role
+  to   = module.ecs_task_execution_role
+}
+
+moved {
+  from = module.lexicon_ecs_task_role
+  to   = module.ecs_task_role
+}
+
+moved {
+  from = module.lexicon_ecs_service
+  to   = module.ecs_service
 }

--- a/services/lexicon/egress.tf
+++ b/services/lexicon/egress.tf
@@ -1,10 +1,15 @@
-module "lexicon_all_egress_rule" {
+module "all_egress_rule" {
   source = "../../modules/aws/security_group/egress_all"
   security_group_id_map = {
-    database           = module.lexicon_database_security_group.id
-    session_management = module.lexicon_session_management_security_group.id
-    alb                = module.lexicon_load_balancer_security_group.id
-    ecs                = module.lexicon_ecs_security_group.id
+    database           = module.database_security_group.id
+    session_management = module.session_management_security_group.id
+    alb                = module.load_balancer_security_group.id
+    ecs                = module.ecs_security_group.id
     redis              = module.redis_security_group.id
   }
+}
+
+moved {
+  from = module.lexicon_all_egress_rule
+  to   = module.all_egress_rule
 }

--- a/services/lexicon/github.tf
+++ b/services/lexicon/github.tf
@@ -1,4 +1,4 @@
-module "lexicon_repository" {
+module "repository" {
   source             = "../../modules/github/repository"
   name               = "lexicon"
   description        = "The true successor to Neurosongs, allowing users to write blogs, share them, and track revision history."
@@ -6,21 +6,26 @@ module "lexicon_repository" {
   required_ci_checks = var.required_ci_checks
   alex_up_bot_app_id = var.alex_up_bot_app_id
   variables = {
-    AWS_ROLE_ARN              = module.lexicon_deployment_role.role_arn
-    AWS_CLUSTER_NAME          = module.lexicon_ecs_service.cluster_name
-    AWS_SERVICE_NAME          = module.lexicon_ecs_service.service_name
-    AWS_MIGRATION_TASK_FAMILY = module.lexicon_ecs_service.task_families["migrate"]
+    AWS_ROLE_ARN              = module.deployment_role.role_arn
+    AWS_CLUSTER_NAME          = module.ecs_service.cluster_name
+    AWS_SERVICE_NAME          = module.ecs_service.service_name
+    AWS_MIGRATION_TASK_FAMILY = module.ecs_service.task_families["migrate"]
     AWS_REGION                = var.aws_region
-    AWS_SECURITY_GROUP_ID     = module.lexicon_ecs_security_group.id
-    AWS_SUBNET_IDS            = join(",", module.lexicon_ecs_service.subnet_ids)
-    AWS_ASSIGN_PUBLIC_IP      = module.lexicon_ecs_service.assign_public_ip ? "ENABLED" : "DISABLED"
-    AWS_ECR_REPOSITORY_URL    = module.lexicon_ecr_image.repository_url
-    FRONT_END_SENTRY_DSN      = module.lexicon_sentry_front_end.public_dsn
+    AWS_SECURITY_GROUP_ID     = module.ecs_security_group.id
+    AWS_SUBNET_IDS            = join(",", module.ecs_service.subnet_ids)
+    AWS_ASSIGN_PUBLIC_IP      = module.ecs_service.assign_public_ip ? "ENABLED" : "DISABLED"
+    AWS_ECR_REPOSITORY_URL    = module.ecr_image.repository_url
+    FRONT_END_SENTRY_DSN      = module.sentry_front_end.public_dsn
   }
   labels = var.github_labels
 }
 
-data "aws_iam_policy_document" "lexicon_deploy" {
+moved {
+  from = module.lexicon_repository
+  to   = module.repository
+}
+
+data "aws_iam_policy_document" "deploy" {
   statement {
     effect = "Allow"
 
@@ -50,16 +55,21 @@ data "aws_iam_policy_document" "lexicon_deploy" {
     ]
 
     resources = [
-      module.lexicon_ecs_task_execution_role.role_arn,
-      module.lexicon_ecs_task_role.role_arn
+      module.ecs_task_execution_role.role_arn,
+      module.ecs_task_role.role_arn
     ]
   }
 }
 
-module "lexicon_deployment_role" {
+module "deployment_role" {
   source            = "../../modules/aws/iam/roles/github"
-  repository        = module.lexicon_repository.full_name
+  repository        = module.repository.full_name
   role_name         = "lexicon-deployment"
   oidc_provider_arn = var.deployment_role_oidc_provider_arn
-  policy_json       = data.aws_iam_policy_document.lexicon_deploy.json
+  policy_json       = data.aws_iam_policy_document.deploy.json
+}
+
+moved {
+  from = module.lexicon_deployment_role
+  to   = module.deployment_role
 }

--- a/services/lexicon/image.tf
+++ b/services/lexicon/image.tf
@@ -1,4 +1,9 @@
-module "lexicon_ecr_image" {
+module "ecr_image" {
   source = "../../modules/aws/ecr"
   name   = "lexicon"
+}
+
+moved {
+  from = module.lexicon_ecr_image
+  to   = module.ecr_image
 }

--- a/services/lexicon/ingress.tf
+++ b/services/lexicon/ingress.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc_security_group_ingress_rule" "session_management_to_database" {
-  security_group_id = module.lexicon_database_security_group.id
+  security_group_id = module.database_security_group.id
 
-  referenced_security_group_id = module.lexicon_session_management_security_group.id
+  referenced_security_group_id = module.session_management_security_group.id
 
   from_port   = 5432
   to_port     = 5432
@@ -9,9 +9,9 @@ resource "aws_vpc_security_group_ingress_rule" "session_management_to_database" 
 }
 
 resource "aws_vpc_security_group_ingress_rule" "alb_to_ecs" {
-  security_group_id = module.lexicon_ecs_security_group.id
+  security_group_id = module.ecs_security_group.id
 
-  referenced_security_group_id = module.lexicon_load_balancer_security_group.id
+  referenced_security_group_id = module.load_balancer_security_group.id
 
   from_port   = local.backend_port
   to_port     = local.backend_port
@@ -19,9 +19,9 @@ resource "aws_vpc_security_group_ingress_rule" "alb_to_ecs" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ecs_to_database" {
-  security_group_id = module.lexicon_database_security_group.id
+  security_group_id = module.database_security_group.id
 
-  referenced_security_group_id = module.lexicon_ecs_security_group.id
+  referenced_security_group_id = module.ecs_security_group.id
 
   from_port   = 5432
   to_port     = 5432
@@ -29,7 +29,7 @@ resource "aws_vpc_security_group_ingress_rule" "ecs_to_database" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http" {
-  security_group_id = module.lexicon_load_balancer_security_group.id
+  security_group_id = module.load_balancer_security_group.id
 
   from_port   = 80
   to_port     = 80
@@ -38,7 +38,7 @@ resource "aws_vpc_security_group_ingress_rule" "http" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https" {
-  security_group_id = module.lexicon_load_balancer_security_group.id
+  security_group_id = module.load_balancer_security_group.id
 
   from_port   = 443
   to_port     = 443
@@ -49,7 +49,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
 resource "aws_vpc_security_group_ingress_rule" "redis" {
   security_group_id = module.redis_security_group.id
 
-  referenced_security_group_id = module.lexicon_ecs_security_group.id
+  referenced_security_group_id = module.ecs_security_group.id
 
   from_port   = 6379
   to_port     = 6379

--- a/services/lexicon/load_balancer.tf
+++ b/services/lexicon/load_balancer.tf
@@ -1,12 +1,12 @@
-module "lexicon_acm_certificate" {
+module "acm_certificate" {
   source                    = "../../modules/aws/acm_certificate"
   domain_name               = var.lexicon_domain
   subject_alternative_names = ["www.${var.lexicon_domain}"]
 }
 
-module "lexicon_dns_validation_records" {
+module "dns_validation_records" {
   for_each = {
-    for option in module.lexicon_acm_certificate.domain_validation_options :
+    for option in module.acm_certificate.domain_validation_options :
     option.domain_name => option
   }
 
@@ -21,23 +21,43 @@ module "lexicon_dns_validation_records" {
   ttl     = 660
 }
 
-module "lexicon_acm_certificate_validation" {
+module "acm_certificate_validation" {
   source = "../../modules/aws/certificate_validation"
 
-  certificate_arn = module.lexicon_acm_certificate.certificate_arn
+  certificate_arn = module.acm_certificate.certificate_arn
   validation_record_fqdns = [
-    for record in module.lexicon_dns_validation_records :
+    for record in module.dns_validation_records :
     record.fqdn
   ]
 }
 
-module "lexicon_load_balancer" {
+module "load_balancer" {
   source             = "../../modules/aws/load_balancer"
   name               = "lexicon"
   health_check_path  = "/api/v1"
   port               = local.backend_port
-  certificate_arn    = module.lexicon_acm_certificate_validation.validated_certificate_arn
+  certificate_arn    = module.acm_certificate_validation.validated_certificate_arn
   vpc_id             = var.vpc_id
   subnet_ids         = var.public_subnet_ids
-  security_group_ids = [module.lexicon_load_balancer_security_group.id]
+  security_group_ids = [module.load_balancer_security_group.id]
+}
+
+moved {
+  from = module.lexicon_acm_certificate
+  to   = module.acm_certificate
+}
+
+moved {
+  from = module.lexicon_dns_validation_records
+  to   = module.dns_validation_records
+}
+
+moved {
+  from = module.lexicon_acm_certificate_validation
+  to   = module.acm_certificate_validation
+}
+
+moved {
+  from = module.lexicon_load_balancer
+  to   = module.load_balancer
 }

--- a/services/lexicon/monitoring.tf
+++ b/services/lexicon/monitoring.tf
@@ -2,10 +2,10 @@ resource "sentry_organization_repository" "github" {
   organization     = var.sentry_organisation_id
   integration_type = "github"
   integration_id   = var.sentry_github_integration_id
-  identifier       = module.lexicon_repository.full_name
+  identifier       = module.repository.full_name
 }
 
-module "lexicon_sentry_back_end" {
+module "sentry_back_end" {
   source                = "../../modules/sentry/project"
   name                  = "lexicon-back-end"
   organisation_id       = var.sentry_organisation_id
@@ -16,7 +16,7 @@ module "lexicon_sentry_back_end" {
   source_root           = "apps/back-end/src"
 }
 
-module "lexicon_sentry_front_end" {
+module "sentry_front_end" {
   source                = "../../modules/sentry/project"
   organisation_id       = var.sentry_organisation_id
   teams                 = ["alextheman231"]
@@ -25,4 +25,14 @@ module "lexicon_sentry_front_end" {
   github_integration_id = var.sentry_github_integration_id
   sentry_repository_id  = sentry_organization_repository.github.id
   source_root           = "apps/front-end/src"
+}
+
+moved {
+  from = module.lexicon_sentry_back_end
+  to   = module.sentry_back_end
+}
+
+moved {
+  from = module.lexicon_sentry_front_end
+  to   = module.sentry_front_end
 }

--- a/services/lexicon/outputs.tf
+++ b/services/lexicon/outputs.tf
@@ -1,3 +1,3 @@
 output "secret_manager_arn" {
-  value = module.lexicon_secrets.arn
+  value = module.secrets.arn
 }

--- a/services/lexicon/secrets.tf
+++ b/services/lexicon/secrets.tf
@@ -1,12 +1,17 @@
-module "lexicon_secrets" {
+module "secrets" {
   source = "../../modules/aws/secrets_manager"
   name   = "lexicon"
   secrets = {
-    DATABASE_URL         = module.lexicon_database.database_url
+    DATABASE_URL         = module.database.database_url
     GOOGLE_CLIENT_SECRET = var.lexicon_google_client_secret
   }
   plan_role_id = var.plan_role_id
   allowed_role_ids = {
-    ecs_task_execution = module.lexicon_ecs_task_execution_role.role_id
+    ecs_task_execution = module.ecs_task_execution_role.role_id
   }
+}
+
+moved {
+  from = module.lexicon_secrets
+  to   = module.secrets
 }

--- a/services/lexicon/security_groups.tf
+++ b/services/lexicon/security_groups.tf
@@ -1,25 +1,25 @@
-module "lexicon_database_security_group" {
+module "database_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-prod-database"
   vpc_id = var.vpc_id
 }
 
-module "lexicon_session_management_security_group" {
+module "session_management_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-session-management"
   vpc_id = var.vpc_id
 }
 
-module "lexicon_load_balancer_security_group" {
+module "load_balancer_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-alb"
   vpc_id = var.vpc_id
 }
 
-module "lexicon_ecs_security_group" {
+module "ecs_security_group" {
   source = "../../modules/aws/security_group"
 
   name   = "lexicon-ecs"
@@ -31,4 +31,24 @@ module "redis_security_group" {
 
   name   = "lexicon-redis"
   vpc_id = var.vpc_id
+}
+
+moved {
+  from = module.lexicon_database_security_group
+  to   = module.database_security_group
+}
+
+moved {
+  from = module.lexicon_load_balancer_security_group
+  to   = module.load_balancer_security_group
+}
+
+moved {
+  from = module.lexicon_session_management_security_group
+  to   = module.session_management_security_group
+}
+
+moved {
+  from = module.lexicon_ecs_security_group
+  to   = module.ecs_security_group
 }


### PR DESCRIPTION
It doesn't really need it given that these resources are in module.lexicon, and so these can already be implied to be part of the Lexicon setup without the prefix needing to be there (from module.lexicon).

# Refactor

This is a change to the code layout of `infrastructure`. It changes how the code is presented in terms of quality and structure without changing the overall plan.

Please see the commits tab of this pull request for the description of changes.
