### PR TITLE
Use three subnets, but make it the upper bound

### DIFF
--- a/modules/aws/network/locals.tf
+++ b/modules/aws/network/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  subnet_count = 3
+  subnet_count = min(3, length(data.aws_availability_zones.available.names))
 }


### PR DESCRIPTION
So in case we ever did get less than three names from the availability zone, it won't error due to an out-of-bounds exception (even if it will still break the infrastructure...)

# Description of Changes

## Risk level: Low

This is a low risk change because it consists of changes that are not expected to change the Terraform state. It must pass the CI checks in order for changes to be merged and deployed, and the plan must show absolutely no changes before merge.

## Type of Change

The type of changes made can be found on the labels associated with the pull request. The exact changes made can be found under the commits tab.
